### PR TITLE
History tracking of user guesses per round

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,0 +1,46 @@
+"use strict";
+exports.__esModule = true;
+exports.logger = exports.findAndSendMatch = void 0;
+function findAndSendMatch(query, receivedResp, res) {
+    for (var i in receivedResp.data) {
+        var searchResult = findWord(query, receivedResp.data[i]);
+        console.log("searchResult: ", receivedResp.data[i]);
+        if (searchResult !== undefined) {
+            var element = receivedResp.data[i];
+            res.send(createFoundResponse(element, searchResult));
+            return true;
+        }
+    }
+    return false;
+}
+exports.findAndSendMatch = findAndSendMatch;
+function findWord(query, potentialResult) {
+    return potentialResult.japanese.find(function (el) { return matchReading(query, el.reading) || matchWord(query, el.word); });
+}
+function createFoundResponse(element, searchResult) {
+    var index = element.japanese.findIndex(function (el) { return el.reading.localeCompare(searchResult.reading) === 0; });
+    var japanese = element.japanese[index];
+    var english = element.senses[index].english_definitions;
+    var entry = {
+        slug: element.slug,
+        japanese: japanese,
+        english: english
+    };
+    return { found: true, entry: entry };
+}
+function matchReading(query, reading) {
+    return (reading === null || reading === void 0 ? void 0 : reading.localeCompare(query)) === 0;
+}
+function matchWord(query, word) {
+    return (word === null || word === void 0 ? void 0 : word.localeCompare(query)) === 0;
+}
+function logger(req, _, next) {
+    if (req.method !== "POST" && req.url !== "/search") {
+        console.log(req.method, req.url, req.body);
+        next();
+        return;
+    }
+    console.log(req.method, req.url, decodeURI(req.body.query));
+    next();
+}
+exports.logger = logger;

--- a/server/helpers.ts
+++ b/server/helpers.ts
@@ -1,0 +1,86 @@
+import { Next, Request, Response } from 'express';
+
+interface JoshiResponse {
+  data: Array<JoshiElement>;
+}
+interface JoshiElement {
+  slug: string;
+  japanese: Array<JapaneseEntry>;
+  senses: Array<Sense>;
+}
+interface JapaneseEntry {
+  reading: string;
+  word: string;
+}
+interface Sense {
+  english_definitions: Array<string>;
+  sentences: Array<string>;
+}
+
+interface ApiResponse {
+  found: boolean;
+  entry: ApiEntry;
+}
+interface ApiEntry {
+  slug: string;
+  japanese: JapaneseEntry;
+  english: Array<string>;
+}
+
+function findAndSendMatch(query: string, receivedResp: JoshiResponse, res: Response): boolean {
+  for (const i in receivedResp.data) {
+    const searchResult = findWord(query, receivedResp.data[i]);
+    console.log(`searchResult: `, receivedResp.data[i]);
+
+    if (searchResult !== undefined) {
+      const element = receivedResp.data[i];
+      res.send(createFoundResponse(element, searchResult));
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function findWord(query: string, potentialResult: JoshiElement): JapaneseEntry | undefined {
+  return potentialResult.japanese.find(
+    el => matchReading(query, el.reading) || matchWord(query, el.word)
+  );
+}
+
+function createFoundResponse(element: JoshiElement, searchResult: JapaneseEntry): ApiResponse {
+  const index = element.japanese.findIndex(
+    el => el.reading.localeCompare(searchResult.reading) === 0
+  );
+  const japanese = element.japanese[index];
+  const english = element.senses[index].english_definitions;
+  const entry = {
+    slug: element.slug,
+    japanese,
+    english,
+  }
+  return { found: true, entry };
+}
+
+function matchReading(query: string, reading: string | undefined): boolean {
+  return reading?.localeCompare(query) === 0;
+}
+function matchWord(query: string, word: string | undefined): boolean {
+  return word?.localeCompare(query) === 0;
+}
+
+function logger(req: Request, _, next: Next) {
+  if (req.method !== "POST" && req.url !== "/search") {
+    console.log(req.method, req.url, req.body);
+    next();
+    return;
+  }
+
+  console.log(req.method, req.url, decodeURI(req.body.query));
+  next();
+}
+
+export {
+  findAndSendMatch,
+  logger,
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,14 +1,15 @@
 "use strict";
 exports.__esModule = true;
+var node_fetch_1 = require("node-fetch");
 var bodyParser = require('body-parser');
 var express = require('express');
 var fs = require("fs");
-var node_fetch_1 = require("node-fetch");
+var helpers_1 = require("./helpers");
 var app = express();
 var PORT = process.env.PORT || 3000;
 var baseURL = "https://jisho.org/api/v1/search";
 app.use(bodyParser.json());
-app.use(logger);
+app.use(helpers_1.logger);
 app.get("/api/", function (_, res) {
     res.send("ようこそ！");
 });
@@ -45,36 +46,12 @@ app.post("/api/search", function (req, res) {
             res.send({ found: false, msg: "No data" });
             return;
         }
-        for (var _i = 0, _a = r.data; _i < _a.length; _i++) {
-            var potentialResult = _a[_i];
-            var searchResult = findWord(query, potentialResult);
-            console.log("searchResult: " + searchResult);
-            if (searchResult !== undefined) {
-                res.send({ found: true, entry: searchResult });
-                return;
-            }
+        if (!helpers_1.findAndSendMatch(query, r, res)) {
+            res.send({ found: false, response: r });
         }
-        res.send({ found: false, response: r });
+        res.end();
     });
 });
 app.listen(PORT, function () {
     console.log("We are live on port " + PORT + "!");
 });
-function findWord(query, potentialResult) {
-    return potentialResult.japanese.find(function (el) { return matchReading(query, el.reading) || matchWord(query, el.word); });
-}
-function matchReading(query, reading) {
-    return (reading === null || reading === void 0 ? void 0 : reading.localeCompare(query)) === 0;
-}
-function matchWord(query, word) {
-    return (word === null || word === void 0 ? void 0 : word.localeCompare(query)) === 0;
-}
-function logger(req, _, next) {
-    if (req.method !== "POST" && req.url !== "/search") {
-        console.log(req.method, req.url, req.body);
-        next();
-        return;
-    }
-    console.log(req.method, req.url, decodeURI(req.body.query));
-    next();
-}

--- a/src/scripts/game/vocabulary/helper_atoms.ts
+++ b/src/scripts/game/vocabulary/helper_atoms.ts
@@ -117,6 +117,7 @@ function convertSmallChars(word: string, mode: DebugMode = "normal"): string {
 }
 
 export {
+  Entry,
   Response,
   Vocabulary,
   kanaGroups,

--- a/src/scripts/game/vocabulary/helper_atoms.ts
+++ b/src/scripts/game/vocabulary/helper_atoms.ts
@@ -34,10 +34,16 @@ const katakanaToHiragana = {
 
 interface Response {
   found: boolean;
-  entry: {
-    reading: string;
-    word: string;
-  }
+  entry: Entry;
+}
+interface Entry {
+  slug: string;
+  japanese: Japanese,
+  english: Array<string>;
+}
+interface Japanese {
+  reading: string;
+  word: string;
 }
 
 interface Vocabulary {

--- a/src/scripts/game/vocabulary/helpers.ts
+++ b/src/scripts/game/vocabulary/helpers.ts
@@ -1,5 +1,6 @@
 import * as wanakana from "wanakana";
 import {
+  Entry,
   Response,
   Vocabulary,
   kanaGroups,
@@ -9,7 +10,7 @@ import {
 } from "./helper_atoms";
 import { DebugMode, apiRequest, debug, } from "../../helpers";
 
-async function searchUsersGuess(currentWord: string, query: string, mode?: DebugMode): Promise<string> {
+async function searchUsersGuess(currentWord: string, query: string, mode?: DebugMode): Promise<Entry> {
   debug(mode, [`guess`, query]);
 
   return validateQuery(currentWord, query)
@@ -23,9 +24,7 @@ async function searchUsersGuess(currentWord: string, query: string, mode?: Debug
         debug(mode, [r]);
 
         return validateResponse(r, currentWord)
-          .then(_ => Promise.resolve(
-            convertSmallChars(r.entry?.japanese?.reading || "")
-          ));
+          .then(_ => Promise.resolve(r.entry));
       })
     );
 }

--- a/src/scripts/game/vocabulary/helpers.ts
+++ b/src/scripts/game/vocabulary/helpers.ts
@@ -24,7 +24,7 @@ async function searchUsersGuess(currentWord: string, query: string, mode?: Debug
 
         return validateResponse(r, currentWord)
           .then(_ => Promise.resolve(
-            convertSmallChars(r.entry?.reading || "")
+            convertSmallChars(r.entry?.japanese?.reading || "")
           ));
       })
     );
@@ -58,11 +58,11 @@ async function validateResponse(response: Response, currentWord: string): Promis
     return Promise.reject(Error("No exact matches in the Joshi dictionary"));
   }
 
-  if (!isValid(response.entry?.reading)) {
+  if (!isValid(response.entry?.japanese?.reading)) {
     return Promise.reject(Error("User's kanji input ends with unacceptable character"));
   }
 
-  if (!startsWithLastChar(currentWord, response.entry?.reading)) {
+  if (!startsWithLastChar(currentWord, response.entry?.japanese?.reading)) {
     return Promise.reject(Error("User's kanji input's first character doesn't match given word's last character"));
   }
 

--- a/src/scripts/game/vocabulary/history.ts
+++ b/src/scripts/game/vocabulary/history.ts
@@ -1,0 +1,27 @@
+import { DebugMode, debug } from "../../helpers";
+import { Entry } from "./helper_atoms";
+
+/**
+ * Tracks successful user guesses to prevent duplicates
+ */
+export default function History(mode?: DebugMode) {
+  let cache = {};
+
+  return {
+    /**
+     * Verifies if user's guess is in the cache or not - T meaning the guess is valid
+     */
+    check: function (entry: Entry): boolean {
+      debug(mode, [`history check`, !cache[entry.slug]]);
+      return !cache[entry.slug];
+    },
+    add: function (entry: Entry): void {
+      cache[entry.slug] = entry;
+      debug(mode, [`history after add`, cache]);
+    },
+    clear: function (): void {
+      cache = {};
+      debug(mode, [`history cleared`, cache]);
+    },
+  };
+}

--- a/src/scripts/game/vocabulary/index.ts
+++ b/src/scripts/game/vocabulary/index.ts
@@ -1,3 +1,4 @@
+import History from "./history";
 import {
   Vocabulary,
   compileVocabulary,
@@ -7,11 +8,13 @@ import {
   selectChar,
   selectWord,
 } from "./helpers";
+import { convertSmallChars } from "./helper_atoms";
 
 export default function Vocab() {
   let vocab: JSON = null;
   let currentWord: string = null;
   let nextFirst: string = null;
+  const history = History();
 
   return {
     init: function (): void {
@@ -28,12 +31,18 @@ export default function Vocab() {
 
     searchUsersGuess: function (query) {
       return searchUsersGuess(currentWord, query)
-        .then(guessWord => {
-          nextFirst = guessWord;
+        .then(entry => {
+          if (!history.check(entry)) {
+            return Promise.reject(Error("This word was already used this round"));
+          }
+
+          nextFirst = convertSmallChars(entry?.japanese?.reading || "");
+          history.add(entry);
           return Promise.resolve();
         })
         .catch(err => {
           nextFirst = null;
+          history.clear();
           return Promise.reject(err);
         });
     },


### PR DESCRIPTION
1. Pass slug for each verified word after confirming with Joshi's API and sending it from the backend to the front
2. Refactor the backend and split helpers into their own file to lessen the noise and better organization
3. Also pass the english definitions that come with Joshi's API response to the front end so it could be used later on
4. Create a history cache API to be used within Vocab to look up, add and clear slugs