### PR TITLE
Transitions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -94,7 +94,7 @@
 
           <div class="game-ui__input">
             <form id="guessForm" name="guessForm" method="post">
-              <input type="text" name="guessForm" id="guessInput" minlength="1" required
+              <input id="guessInput" type="text" name="guessForm" minlength="1" required
                 placeholder="何がいいかな">
             </form>
             <p>Hit enter to submit</p>

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -20,7 +20,7 @@ function findWord(query, potentialResult) {
 function createFoundResponse(element, searchResult) {
     var index = element.japanese.findIndex(function (el) { return el.reading.localeCompare(searchResult.reading) === 0; });
     var japanese = element.japanese[index];
-    var english = element.senses[index].english_definitions;
+    var english = element.senses[0].english_definitions;
     var entry = {
         slug: element.slug,
         japanese: japanese,

--- a/server/helpers.ts
+++ b/server/helpers.ts
@@ -53,7 +53,7 @@ function createFoundResponse(element: JoshiElement, searchResult: JapaneseEntry)
     el => el.reading.localeCompare(searchResult.reading) === 0
   );
   const japanese = element.japanese[index];
-  const english = element.senses[index].english_definitions;
+  const english = element.senses[0].english_definitions;
   const entry = {
     slug: element.slug,
     japanese,

--- a/src/scripts/game/game.ts
+++ b/src/scripts/game/game.ts
@@ -51,18 +51,26 @@ export default function Game() {
     emojiContainer.classList.add("emoji--slideleft");
     emojiHappy.classList.remove("hide");
 
-    prevWord.classList.add("focus");
-    inputEl.parentElement.parentElement.classList.add("hide");
-
+    emphasizeWord();
     resetInput();
-    displayNextWord();
+    displayWord("next");
     timeouts();
   }
 
-  function displayNextWord() {
-    const startingVocab = vocabInstance.nextWord();
-    prevPrimary.innerText = startingVocab?.Kanji || startingVocab?.Kana;
-    prevSecondary.innerText = startingVocab.Kanji ? startingVocab.Kana : "";
+  function emphasizeWord() {
+    prevWord.classList.add("focus");
+    inputEl.parentElement.parentElement.classList.add("hide");
+  }
+  function resetWordEmphasis() {
+    prevWord.classList.remove("focus", "slide-left");
+    inputEl.parentElement.parentElement.classList.remove("hide");
+    inputEl.focus();
+  }
+
+  function displayWord(type: "start" | "next") {
+    const nextVocab = type === "start" ? vocabInstance.start() : vocabInstance.nextWord();
+    prevPrimary.innerText = nextVocab?.Kanji || nextVocab?.Kana;
+    prevSecondary.innerText = nextVocab.Kanji ? nextVocab.Kana : "";
   }
 
   function timeouts() {
@@ -75,17 +83,12 @@ export default function Game() {
 
       setTimeout(() => {
         emojiContainer.classList.remove("emoji--vanish");
+        prevWord.classList.add("slide-left");
 
         setTimeout(() => {
-          prevWord.classList.add("slide-left");
-          inputEl.parentElement.parentElement.classList.remove("hide");
-
-          setTimeout(() => {
-            prevWord.classList.remove("focus", "slide-left");
-            inputEl.focus();
-          }, 100);
+          resetWordEmphasis();
         }, 100);
-      }, 100);
+      }, 200);
     }, 1000);
   }
 
@@ -94,14 +97,16 @@ export default function Game() {
       landingPic.classList.add("fade-out");
       playBtn.classList.add("fade-out");
 
+      emphasizeWord();
+      displayWord("start")
+
       setTimeout(() => {
         landingPic.remove();
         playBtn.parentElement.remove();
 
-        const startingVocab = vocabInstance.start();
-        prevPrimary.innerText = startingVocab?.Kanji || startingVocab?.Kana;
-        prevSecondary.innerText = startingVocab.Kanji ? startingVocab.Kana : "";
-        inputEl.focus();
+        setTimeout(() => {
+          resetWordEmphasis();
+        }, 800);
       }, 500);
     },
 
@@ -113,9 +118,7 @@ export default function Game() {
       playAgainBtn.parentElement.classList.remove("play-again--show");
       emojiSad.classList.add("hide");
 
-      const startingVocab = vocabInstance.start();
-      prevPrimary.innerText = startingVocab?.Kanji || startingVocab?.Kana;
-      prevSecondary.innerText = startingVocab.Kanji ? startingVocab.Kana : "";
+      displayWord("start");
     },
 
     searchUsersGuess: async function () {

--- a/src/scripts/game/game.ts
+++ b/src/scripts/game/game.ts
@@ -73,14 +73,18 @@ export default function Game() {
 
   return {
     initPlay: function () {
-      landingPic.remove();
-      playBtn.parentElement.remove();
-      gamePic.classList.add("game-bg-pic--active");
-      inputEl.focus();
+      landingPic.classList.add("fade-out");
+      playBtn.classList.add("fade-out");
 
-      const startingVocab = vocabInstance.start();
-      prevPrimary.innerText = startingVocab?.Kanji || startingVocab?.Kana;
-      prevSecondary.innerText = startingVocab.Kanji ? startingVocab.Kana : "";
+      setTimeout(() => {
+        landingPic.remove();
+        playBtn.parentElement.remove();
+
+        const startingVocab = vocabInstance.start();
+        prevPrimary.innerText = startingVocab?.Kanji || startingVocab?.Kana;
+        prevSecondary.innerText = startingVocab.Kanji ? startingVocab.Kana : "";
+        inputEl.focus();
+      }, 500);
     },
 
     initPlayAgain: function () {

--- a/src/scripts/game/game.ts
+++ b/src/scripts/game/game.ts
@@ -54,17 +54,19 @@ export default function Game() {
     emphasizeWord();
     resetInput();
     displayWord("next");
-    timeouts();
+    activateTransitions();
   }
 
   function emphasizeWord() {
     prevWord.classList.add("focus");
     inputEl.parentElement.parentElement.classList.add("hide");
   }
-  function resetWordEmphasis() {
-    prevWord.classList.remove("focus", "slide-left");
-    inputEl.parentElement.parentElement.classList.remove("hide");
-    inputEl.focus();
+  function resetWordEmphasis(timeout: number) {
+    setTimeout(() => {
+      prevWord.classList.remove("focus", "slide-left");
+      inputEl.parentElement.parentElement.classList.remove("hide");
+      inputEl.focus();
+    }, timeout);
   }
 
   function displayWord(type: "start" | "next") {
@@ -73,7 +75,7 @@ export default function Game() {
     prevSecondary.innerText = nextVocab.Kanji ? nextVocab.Kana : "";
   }
 
-  function timeouts() {
+  function activateTransitions() {
     setTimeout(() => {
       document.body.style.overflowX = "";
       emojiContainer.classList.add("emoji--vanish");
@@ -84,10 +86,7 @@ export default function Game() {
       setTimeout(() => {
         emojiContainer.classList.remove("emoji--vanish");
         prevWord.classList.add("slide-left");
-
-        setTimeout(() => {
-          resetWordEmphasis();
-        }, 100);
+        resetWordEmphasis(100);
       }, 200);
     }, 1000);
   }
@@ -103,22 +102,20 @@ export default function Game() {
       setTimeout(() => {
         landingPic.remove();
         playBtn.parentElement.remove();
-
-        setTimeout(() => {
-          resetWordEmphasis();
-        }, 800);
+        resetWordEmphasis(800);
       }, 500);
     },
 
     initPlayAgain: function () {
       resultOverlay.classList.remove("wrong");
       resetInput();
-      inputEl.focus();
 
       playAgainBtn.parentElement.classList.remove("play-again--show");
       emojiSad.classList.add("hide");
 
+      emphasizeWord();
       displayWord("start");
+      resetWordEmphasis(1300);
     },
 
     searchUsersGuess: async function () {

--- a/src/scripts/game/game.ts
+++ b/src/scripts/game/game.ts
@@ -5,15 +5,15 @@ const vocabInstance = Vocab();
 vocabInstance.init()
 
 export default function Game() {
-  const landingPic: HTMLElement = get("landingPic");
-  const playBtn: HTMLElement = get("playBtn");
-  const gamePic: HTMLElement = get("gamePic");
-  const playAgainBtn: HTMLElement = get("playAgainBtn");
-  const emojiContainer: HTMLElement = get("emoji");;
-  const inputEl: HTMLInputElement = get("guessForm").firstElementChild as HTMLInputElement;
-  const resultOverlay: HTMLElement = get("overlay");
-  const prevPrimary = get("prevWord").firstElementChild as HTMLElement;
-  const prevSecondary = get("prevWord").lastElementChild as HTMLElement;
+  const landingPic = get("landingPic");
+  const playBtn = get("playBtn");
+  const playAgainBtn = get("playAgainBtn");
+  const emojiContainer = get("emoji");;
+  const inputEl = get("guessInput") as HTMLInputElement;
+  const resultOverlay = get("overlay");
+  const prevWord = get("prevWord");
+  const prevPrimary = prevWord.firstElementChild as HTMLElement;
+  const prevSecondary = prevWord.lastElementChild as HTMLElement;
   const emojiSad = emojiContainer.firstElementChild as HTMLElement;
   const emojiHappy = emojiContainer.lastElementChild as HTMLElement;
 
@@ -45,15 +45,29 @@ export default function Game() {
 
   function showCorrectUI(): void {
     resultOverlay.classList.add("correct");
-
     inputEl.classList.add("game-ui__input--correct");
 
     document.body.style.overflowX = "hidden";
     emojiContainer.classList.add("emoji--slideleft");
     emojiHappy.classList.remove("hide");
 
+    prevWord.classList.add("focus");
+    inputEl.parentElement.parentElement.classList.add("hide");
+
+    resetInput();
+    displayNextWord();
+    timeouts();
+  }
+
+  function displayNextWord() {
+    const startingVocab = vocabInstance.nextWord();
+    prevPrimary.innerText = startingVocab?.Kanji || startingVocab?.Kana;
+    prevSecondary.innerText = startingVocab.Kanji ? startingVocab.Kana : "";
+  }
+
+  function timeouts() {
     setTimeout(() => {
-      document.body.style.overflowX = undefined;
+      document.body.style.overflowX = "";
       emojiContainer.classList.add("emoji--vanish");
       emojiHappy.classList.add("hide");
       inputEl.classList.remove("game-ui__input--correct");
@@ -61,14 +75,18 @@ export default function Game() {
 
       setTimeout(() => {
         emojiContainer.classList.remove("emoji--vanish");
-      }, 150);
+
+        setTimeout(() => {
+          prevWord.classList.add("slide-left");
+          inputEl.parentElement.parentElement.classList.remove("hide");
+
+          setTimeout(() => {
+            prevWord.classList.remove("focus", "slide-left");
+            inputEl.focus();
+          }, 100);
+        }, 100);
+      }, 100);
     }, 1000);
-
-    resetInput();
-
-    const startingVocab = vocabInstance.nextWord();
-    prevPrimary.innerText = startingVocab?.Kanji || startingVocab?.Kana;
-    prevSecondary.innerText = startingVocab.Kanji ? startingVocab.Kana : "";
   }
 
   return {
@@ -104,8 +122,6 @@ export default function Game() {
       inputEl.disabled = true;
       return vocabInstance.searchUsersGuess(inputEl.value)
         .then(_ => {
-          inputEl.disabled = false;
-          inputEl.focus();
           showCorrectUI();
         })
         .catch(err => {

--- a/src/scripts/game/game.ts
+++ b/src/scripts/game/game.ts
@@ -62,8 +62,19 @@ export default function Game() {
     inputEl.parentElement.parentElement.classList.add("hide");
   }
   function resetWordEmphasis(timeout: number) {
+    if (window.innerWidth < 1024) {
+      inputEl.parentElement.parentElement.classList.remove("hide");
+      prevWord.classList.remove("focus");
+      inputEl.focus();
+
+      setTimeout(() => {
+        prevWord.classList.remove("slide");
+      }, timeout);
+      return;
+    }
+
     setTimeout(() => {
-      prevWord.classList.remove("focus", "slide-left");
+      prevWord.classList.remove("focus", "slide");
       inputEl.parentElement.parentElement.classList.remove("hide");
       inputEl.focus();
     }, timeout);
@@ -85,7 +96,7 @@ export default function Game() {
 
       setTimeout(() => {
         emojiContainer.classList.remove("emoji--vanish");
-        prevWord.classList.add("slide-left");
+        prevWord.classList.add("slide");
         resetWordEmphasis(100);
       }, 200);
     }, 1000);

--- a/src/scripts/game/game.ts
+++ b/src/scripts/game/game.ts
@@ -11,6 +11,7 @@ export default function Game() {
   const emojiContainer = get("emoji");;
   const inputEl = get("guessInput") as HTMLInputElement;
   const resultOverlay = get("overlay");
+  const underlay = get("underlay");
   const prevWord = get("prevWord");
   const prevPrimary = prevWord.firstElementChild as HTMLElement;
   const prevSecondary = prevWord.lastElementChild as HTMLElement;
@@ -19,6 +20,7 @@ export default function Game() {
 
   function showWrongUI(): void {
     resultOverlay.classList.add("wrong");
+    underlay.classList.add("gameover");
 
     inputEl.classList.add("game-ui__input--wrong");
     inputEl.disabled = true;
@@ -119,6 +121,7 @@ export default function Game() {
 
     initPlayAgain: function () {
       resultOverlay.classList.remove("wrong");
+      underlay.classList.remove("gameover");
       resetInput();
 
       playAgainBtn.parentElement.classList.remove("play-again--show");

--- a/src/styles/footer.scss
+++ b/src/styles/footer.scss
@@ -1,9 +1,13 @@
 footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 67px;
+  padding-right: 1vw;
+
   display: flex;
   justify-content: flex-end;
   align-items: center;
-  height: 67px;
-  padding-right: 1vw;
   box-sizing: border-box;
 
   a {

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -86,10 +86,10 @@
         width: 100%;
       }
 
-      .slide-left {
-        width: 33%;
-        transition: width 100ms ease-out;
-      }
+    .slide {
+      width: 33%;
+      transition: width 100ms ease-out;
+    }
   
     .game-ui__input {
       align-self: center;

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -196,7 +196,7 @@
 
 .wrong {
   background-color: $red;
-  opacity: 0.2;
+  opacity: 0.1;
   z-index: 2;
   transition: opacity 150ms;
 }
@@ -219,4 +219,9 @@
 
 .play-again--show {
   display: flex;
+}
+
+.gameover {
+  display: block;
+  z-index: 1;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -79,7 +79,17 @@
         margin: 0;
         font-size: 18px;
       }
+
     }
+
+    .focus {
+        width: 100%;
+      }
+
+      .slide-left {
+        width: 33%;
+        transition: width 100ms ease-out;
+      }
   
     .game-ui__input {
       align-self: center;
@@ -116,6 +126,11 @@
       .game-ui__input--wrong {
         border: 1px solid $red;
       }
+
+    }
+    
+    .hide {
+      display: none;
     }
   }
 

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -7,6 +7,12 @@
   background-position: center;
 }
 
+.fade-out {
+  position: absolute;
+  opacity: 0;
+  transition: opacity 500ms ease-in;
+}
+
 .play {
   position: absolute;
   width: 100%;
@@ -37,19 +43,12 @@
 .game-bg-pic {
   background-image: url("../images/chureito-fuji-bg-comp95.jpg");
   background-size: cover;
-  height: calc(100vh - 67px - 67px);
   background-position: center;
-  z-index: -1;
   position: absolute;
-  top: 67px;
-  left: 0;
-}
-
-.game-bg-pic--active {
-  position: relative;
   top: 0;
-  left: undefined;
-  z-index: 1;
+  width: 100%;
+  height: calc(100vh - 67px);
+  z-index: -1;
 }
 
 .game-ui {
@@ -69,6 +68,7 @@
       justify-content: center;
       align-items: center;
       width: 33%;
+      word-break: keep-all;
   
       & h1 {
         margin: 0 0 8px 0;

--- a/src/styles/media-queries.scss
+++ b/src/styles/media-queries.scss
@@ -108,6 +108,17 @@
         color: white;
       }
 
+      .focus {
+        flex: 0.5;
+        justify-content: flex-start;
+      }
+
+      .slide {
+        flex: 0;
+        transform: rotate(5deg);
+        transition: flex 100ms ease-out, transform 100ms ease-in;
+      }
+
       .game-ui__input {
   
         input {
@@ -130,6 +141,12 @@
         font-size: calc(24px + (36 - 16) * ((100vw - 300px) / (1440 - 300)));
       }
     }
+  }
+
+  .emoji {
+    height: 50%;
+    top: 20%;
+    justify-content: flex-end;
   }
 
   footer {

--- a/src/styles/media-queries.scss
+++ b/src/styles/media-queries.scss
@@ -5,7 +5,7 @@
     height: 100vh;
   }
 
-  .game-bg-pic--active {
+  .game-bg-pic {
     height: 100vh;
   }
 
@@ -133,12 +133,8 @@
   }
 
   footer {
-    position: absolute;
-    bottom: 0;
     background-color: rgba(255, 255, 255, 0.4);
-    width: 100vw;
     height: calc(67px - 5vmin);
-    z-index: 1;
   }
 }
 


### PR DESCRIPTION
1. Add a fade-out to the landing bg image to reveal the game bg image
--- in order to achieve this I made the footer absolutely positioned to avoid any slight jerking motion when switching backgrounds
2. Add an emphasizing effect by removing the text input and centering the next/starting word and then sliding or moving the word up or left after a short pause to continue with the game
3. Activate the underlay (prior only used for the modal for the menu) when the game is over to help separate the only actionable Play Again button from the rest of the screen elements -- mostly for mobile views since it can seem crowded at the bottom
4. Alter the mentioned transitions above for mobile screens
5. Fixed a bug with the backend for grabbing the `english_definitions` from Joshi