### PR TITLE
Expand Vocab, Prevent Duplicates, Session Storage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node',
+  testEnvironment: 'jsdom',
 };

--- a/server/helpers.js
+++ b/server/helpers.js
@@ -15,10 +15,10 @@ function findAndSendMatch(query, receivedResp, res) {
 }
 exports.findAndSendMatch = findAndSendMatch;
 function findWord(query, potentialResult) {
-    return potentialResult.japanese.find(function (el) { return matchReading(query, el.reading) || matchWord(query, el.word); });
+    return potentialResult.japanese.find(function (el) { return matchReading(query, el === null || el === void 0 ? void 0 : el.reading) || matchWord(query, el === null || el === void 0 ? void 0 : el.word); });
 }
 function createFoundResponse(element, searchResult) {
-    var index = element.japanese.findIndex(function (el) { return el.reading.localeCompare(searchResult.reading) === 0; });
+    var index = element.japanese.findIndex(function (el) { return (el === null || el === void 0 ? void 0 : el.reading.localeCompare(searchResult === null || searchResult === void 0 ? void 0 : searchResult.reading)) === 0 || (el === null || el === void 0 ? void 0 : el.word.localeCompare(searchResult === null || searchResult === void 0 ? void 0 : searchResult.word)) === 0; });
     var japanese = element.japanese[index];
     var english = element.senses[0].english_definitions;
     var entry = {

--- a/server/helpers.ts
+++ b/server/helpers.ts
@@ -9,8 +9,8 @@ interface JoshiElement {
   senses: Array<Sense>;
 }
 interface JapaneseEntry {
-  reading: string;
-  word: string;
+  reading?: string;
+  word?: string;
 }
 interface Sense {
   english_definitions: Array<string>;
@@ -44,13 +44,13 @@ function findAndSendMatch(query: string, receivedResp: JoshiResponse, res: Respo
 
 function findWord(query: string, potentialResult: JoshiElement): JapaneseEntry | undefined {
   return potentialResult.japanese.find(
-    el => matchReading(query, el.reading) || matchWord(query, el.word)
+    el => matchReading(query, el?.reading) || matchWord(query, el?.word)
   );
 }
 
 function createFoundResponse(element: JoshiElement, searchResult: JapaneseEntry): ApiResponse {
   const index = element.japanese.findIndex(
-    el => el.reading.localeCompare(searchResult.reading) === 0
+    el => el?.reading.localeCompare(searchResult?.reading) === 0 || el?.word.localeCompare(searchResult?.word) === 0
   );
   const japanese = element.japanese[index];
   const english = element.senses[0].english_definitions;

--- a/server/index.js
+++ b/server/index.js
@@ -49,6 +49,7 @@ app.post("/api/search", function (req, res) {
         if (!helpers_1.findAndSendMatch(query, r, res)) {
             res.send({ found: false, response: r });
         }
+        console.log("nothing found");
         res.end();
     });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -59,6 +59,7 @@ app.post("/api/search", (req: Request, res: Response) => {
         res.send({ found: false, response: r });
       }
 
+      console.log(`nothing found`);
       res.end();
     });
 });

--- a/src/scripts/game/vocabulary/helper_atoms.ts
+++ b/src/scripts/game/vocabulary/helper_atoms.ts
@@ -47,6 +47,7 @@ interface Japanese {
 }
 
 interface Vocabulary {
+  ID: string;
   Kana: string;
   Kanji: string;
   Definition: string;

--- a/src/scripts/game/vocabulary/helpers.ts
+++ b/src/scripts/game/vocabulary/helpers.ts
@@ -175,6 +175,9 @@ function selectChar(vocab, char: string, mode?: DebugMode): string {
   if (vocab && (!vocab[char] || !vocab[char].length)) {
     const nextChar = getRandomChar();
     debug(mode, [`no selection to choose from. trying ${nextChar}`]);
+    // TODO: make call to Joshi for a word, new backend endpoint
+    // https://jisho.org/api/v1/search/words?keyword=た*
+    // https://jisho.org/docs
     return selectChar(vocab, nextChar);
   }
 
@@ -202,15 +205,30 @@ function compileVocabulary(res: JSON, vocab: null | JSON): JSON {
   return vocab;
 }
 
+function removeWordFromVocab(selectedWord: Vocabulary, vocab: JSON): JSON {
+  const selectedInitial = ensureHiragana(selectedWord.Kana.substring(0, 1));
+  const selectedIndex = (vocab[selectedInitial] as Array<Vocabulary>).findIndex(el => el.ID.localeCompare(selectedWord.ID) === 0);
+
+  if (selectedIndex === -1) {
+    console.warn(`Couldn't locate word`, selectedWord);
+    console.warn(`Removal failed`);
+    return vocab;
+  }
+
+  vocab[selectedInitial].splice(selectedIndex, 1);
+  return vocab;
+}
+
 
 export {
   Vocabulary,
+  compileVocabulary,
   getRandomChar,
   getVocabulary,
+  removeWordFromVocab,
   searchUsersGuess,
   selectChar,
   selectWord,
-  compileVocabulary
 }
 
 export const Test = {

--- a/src/scripts/game/vocabulary/helpers.ts
+++ b/src/scripts/game/vocabulary/helpers.ts
@@ -186,12 +186,19 @@ function getVocabulary(level: number): Promise<JSON> {
     .then(JSON.parse);
 }
 
-function compileVocabulary(res: JSON, vocab: null | JSON) {
+function compileVocabulary(res: JSON, vocab: null | JSON): JSON {
   if (!vocab) {
     vocab = res;
     return vocab;
   }
-  vocab = { ...vocab, ...res };
+
+  Object.keys(res).forEach(key => {
+    if (Object.keys(vocab).includes(key)) {
+      vocab[key] = vocab[key].concat(res[key]);
+    } else {
+      vocab[key] = res[key];
+    }
+  });
   return vocab;
 }
 

--- a/src/scripts/game/vocabulary/history.ts
+++ b/src/scripts/game/vocabulary/history.ts
@@ -1,5 +1,5 @@
 import { DebugMode, debug } from "../../helpers";
-import { Entry, Vocabulary } from "./helper_atoms";
+import { Entry } from "./helper_atoms";
 
 /**
  * Tracks successful user guesses to prevent duplicates
@@ -11,55 +11,22 @@ export default function History(mode?: DebugMode) {
     /**
      * Verifies if user's guess is in the cache or not - T meaning the guess is valid
      */
-    check: function (entry: Entry | Vocabulary): boolean {
-      debug(mode, [`history check`]);
-
-      if (entry["slug"]) {
-        const idCheck = !cache[entry["slug"]];
-        const kanjiCheck = entry["japanese"]["word"] ? !Object.values(cache).find((el: Entry | Vocabulary) => {
-          if (el["slug"] && el["japanese"] && !!el["japanese"]["word"]) {
-            return el["japanese"]["word"].localeCompare(entry["japanese"]["word"]) === 0;
-          }
-          if (el["Kanji"] && !!entry["japanese"]["word"]) {
-            return el["Kanji"].localeCompare(entry["japanese"]["word"]) === 0;
-          }
-          return false;
-        }) : true;
-
-        console.log(`history check Entry`, idCheck);
-        console.log(`history check Entry`, kanjiCheck);
-        return idCheck && kanjiCheck;
-      }
-
-      const idCheck = !cache[entry["ID"]];
-      const kanjiCheck = !!entry["Kanji"] ? !Object.values(cache).find((el: Entry | Vocabulary) => {
-        if (!!el["Kanji"]) {
-          return entry["Kanji"].localeCompare(el["Kanji"]) === 0;
-        }
-        if (el["japanese"] && !!el["japanese"]["word"]) {
-          return entry["Kanji"].localeCompare(el["japanese"]["word"]) === 0;
-        }
-        return false;
-      }) : true;
-
-      console.log(`history check Vocab`, idCheck);
-      console.log(`history check Vocab`, kanjiCheck);
-      return idCheck && kanjiCheck;
+    check: function (entry: Entry): boolean {
+      debug(mode, [`history check`, !cache[entry.slug]]);
+      return !cache[entry.slug];
     },
-    add: function (entry: Entry | Vocabulary): void {
-      if (entry["slug"]) {
-        cache[entry["slug"]] = entry;
-        console.log(`history adding Entry`, entry);
-      } else {
-        cache[entry["ID"]] = entry;
-        console.log(`history adding Vocab`, entry);
-      }
-
+    add: function (entry: Entry): void {
+      cache[entry.slug] = entry;
       debug(mode, [`history after add`, cache]);
     },
     clear: function (): void {
       cache = {};
       debug(mode, [`history cleared`, cache]);
     },
+    test: {
+      getEntries: function () {
+        return Object.entries(cache);
+      }
+    }
   };
 }

--- a/src/scripts/game/vocabulary/history.ts
+++ b/src/scripts/game/vocabulary/history.ts
@@ -1,5 +1,5 @@
 import { DebugMode, debug } from "../../helpers";
-import { Entry } from "./helper_atoms";
+import { Entry, Vocabulary } from "./helper_atoms";
 
 /**
  * Tracks successful user guesses to prevent duplicates
@@ -11,12 +11,50 @@ export default function History(mode?: DebugMode) {
     /**
      * Verifies if user's guess is in the cache or not - T meaning the guess is valid
      */
-    check: function (entry: Entry): boolean {
-      debug(mode, [`history check`, !cache[entry.slug]]);
-      return !cache[entry.slug];
+    check: function (entry: Entry | Vocabulary): boolean {
+      debug(mode, [`history check`]);
+
+      if (entry["slug"]) {
+        const idCheck = !cache[entry["slug"]];
+        const kanjiCheck = entry["japanese"]["word"] ? !Object.values(cache).find((el: Entry | Vocabulary) => {
+          if (el["slug"] && el["japanese"] && !!el["japanese"]["word"]) {
+            return el["japanese"]["word"].localeCompare(entry["japanese"]["word"]) === 0;
+          }
+          if (el["Kanji"] && !!entry["japanese"]["word"]) {
+            return el["Kanji"].localeCompare(entry["japanese"]["word"]) === 0;
+          }
+          return false;
+        }) : true;
+
+        console.log(`history check Entry`, idCheck);
+        console.log(`history check Entry`, kanjiCheck);
+        return idCheck && kanjiCheck;
+      }
+
+      const idCheck = !cache[entry["ID"]];
+      const kanjiCheck = !!entry["Kanji"] ? !Object.values(cache).find((el: Entry | Vocabulary) => {
+        if (!!el["Kanji"]) {
+          return entry["Kanji"].localeCompare(el["Kanji"]) === 0;
+        }
+        if (el["japanese"] && !!el["japanese"]["word"]) {
+          return entry["Kanji"].localeCompare(el["japanese"]["word"]) === 0;
+        }
+        return false;
+      }) : true;
+
+      console.log(`history check Vocab`, idCheck);
+      console.log(`history check Vocab`, kanjiCheck);
+      return idCheck && kanjiCheck;
     },
-    add: function (entry: Entry): void {
-      cache[entry.slug] = entry;
+    add: function (entry: Entry | Vocabulary): void {
+      if (entry["slug"]) {
+        cache[entry["slug"]] = entry;
+        console.log(`history adding Entry`, entry);
+      } else {
+        cache[entry["ID"]] = entry;
+        console.log(`history adding Vocab`, entry);
+      }
+
       debug(mode, [`history after add`, cache]);
     },
     clear: function (): void {

--- a/src/scripts/game/vocabulary/index.ts
+++ b/src/scripts/game/vocabulary/index.ts
@@ -4,6 +4,7 @@ import {
   compileVocabulary,
   getRandomChar,
   getVocabulary,
+  removeWordFromVocab,
   searchUsersGuess,
   selectChar,
   selectWord,
@@ -21,16 +22,19 @@ export default function Vocab() {
       getVocabulary(5)
         .then((r: JSON) => {
           vocab = compileVocabulary(r, vocab);
+          window.sessionStorage.setItem("vocab", JSON.stringify(vocab));
         });
 
       getVocabulary(4)
         .then((r: JSON) => {
           vocab = compileVocabulary(r, vocab);
+          window.sessionStorage.setItem("vocab", JSON.stringify(vocab));
         });
 
       getVocabulary(3)
         .then((r: JSON) => {
           vocab = compileVocabulary(r, vocab);
+          window.sessionStorage.setItem("vocab", JSON.stringify(vocab));
         });
     },
 
@@ -53,6 +57,7 @@ export default function Vocab() {
     },
 
     start: function () {
+      vocab = JSON.parse(window.sessionStorage.getItem("vocab"));
       console.log(`vocab start`);
       nextFirst = getRandomChar();
       return this.nextWord();
@@ -70,14 +75,10 @@ export default function Vocab() {
         return this.start();
       }
 
-      if (!history.check(selectedObj)) {
-        console.log(`check finished -- word was already used, restart process`, selectedObj);
-        return this.start();
-      }
-
       currentWord = selectedObj.Kana;
       console.log(`selected`, selectedObj);
-      history.add(selectedObj);
+
+      vocab = removeWordFromVocab(selectedObj, vocab);
       return selectedObj;
     },
     Test: {

--- a/src/scripts/game/vocabulary/index.ts
+++ b/src/scripts/game/vocabulary/index.ts
@@ -70,8 +70,14 @@ export default function Vocab() {
         return this.start();
       }
 
+      if (!history.check(selectedObj)) {
+        console.log(`check finished -- word was already used, restart process`, selectedObj);
+        return this.start();
+      }
+
       currentWord = selectedObj.Kana;
       console.log(`selected`, selectedObj);
+      history.add(selectedObj);
       return selectedObj;
     },
     Test: {

--- a/src/scripts/game/vocabulary/index.ts
+++ b/src/scripts/game/vocabulary/index.ts
@@ -27,6 +27,11 @@ export default function Vocab() {
         .then((r: JSON) => {
           vocab = compileVocabulary(r, vocab);
         });
+
+      getVocabulary(3)
+        .then((r: JSON) => {
+          vocab = compileVocabulary(r, vocab);
+        });
     },
 
     searchUsersGuess: function (query) {

--- a/src/scripts/helpers.ts
+++ b/src/scripts/helpers.ts
@@ -1,3 +1,5 @@
+import fetch from "node-fetch";
+
 type DebugMode = "normal" | "debug";
 
 function get(el): HTMLElement {

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,0 +1,242 @@
+import History from "../src/scripts/game/vocabulary/history";
+
+describe("History()", () => {
+  describe("check()", () => {
+    it("Checking an empty cache with a new word [Entry]", () => {
+      const history = History();
+      const entry = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "熱い",
+        },
+        english: []
+      };
+      expect(history.check(entry)).toBe(true);
+    });
+
+    it("Checking an empty cache with a new word [Vocab]", () => {
+      const history = History();
+      const entry = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "熱い",
+        Definition: "hot"
+      };
+      expect(history.check(entry)).toBe(true);
+    });
+
+    it("Checking cache with the same exact word [Entry, Entry]", () => {
+      const history = History();
+      const entry = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "熱い",
+        },
+        english: []
+      };
+      history.add(entry);
+      expect(history.check(entry)).toBe(false);
+    });
+
+    it("Checking cache with the same exact word [Vocab, Vocab]", () => {
+      const history = History();
+      const entry = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "熱い",
+        Definition: "hot"
+      };
+      history.add(entry);
+      expect(history.check(entry)).toBe(false);
+    });
+
+    it("Checking cache with the same exact word [Entry, Vocab]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "熱い",
+        },
+        english: []
+      };
+      history.add(entry1);
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "熱い",
+        Definition: "hot"
+      };
+      expect(history.check(entry2)).toBe(false);
+    });
+
+    it("Checking cache with the same exact word [Vocab, Entry]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "熱い",
+        },
+        english: []
+      };
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "熱い",
+        Definition: "hot"
+      };
+      history.add(entry2);
+      expect(history.check(entry1)).toBe(false);
+    });
+
+    it("Checking cache with a word with the same reading but not kanji [Entry, Vocab]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "熱い",
+        },
+        english: []
+      };
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "暑い",
+        Definition: "thick"
+      };
+      history.add(entry1);
+      expect(history.check(entry2)).toBe(true);
+    });
+
+    it("Checking cache with a word with the same reading but not kanji [Vocab, Entry]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "熱い",
+        },
+        english: []
+      };
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "暑い",
+        Definition: "thick"
+      };
+      history.add(entry2);
+      expect(history.check(entry1)).toBe(true);
+    });
+
+    it("Checking cache with a word with the same reading but one w/o kanji [Vocab, Entry]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "熱い",
+        },
+        english: []
+      };
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "",
+        Definition: "thick"
+      };
+      history.add(entry2);
+      expect(history.check(entry1)).toBe(true);
+    });
+
+    it("Checking cache with a word the same reading but both w/o kanji [Vocab, Entry]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "",
+        },
+        english: []
+      };
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "",
+        Definition: "thick"
+      };
+      history.add(entry2);
+      expect(history.check(entry1)).toBe(true);
+    });
+
+    it("Checking cache via slug [Entry, Entry]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "",
+        },
+        english: []
+      };
+      history.add(entry1);
+      expect(history.check(entry1)).toBe(false);
+    });
+
+    it("Checking cache via id [Vocab, Vocab]", () => {
+      const history = History();
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "",
+        Definition: "thick"
+      };
+      history.add(entry2);
+      expect(history.check(entry2)).toBe(false);
+    });
+
+    it("Checking cache via id [Entry, Vocab]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "",
+        },
+        english: []
+      };
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "",
+        Definition: "thick"
+      };
+      history.add(entry1);
+      expect(history.check(entry2)).toBe(true);
+    });
+
+    it("Checking cache via id [Vocab, Entry]", () => {
+      const history = History();
+      const entry1 = {
+        slug: "slug1",
+        japanese: {
+          reading: "あつい",
+          word: "",
+        },
+        english: []
+      };
+      const entry2 = {
+        ID: "id1",
+        Kana: "あつい",
+        Kanji: "",
+        Definition: "thick"
+      };
+      history.add(entry2);
+      expect(history.check(entry1)).toBe(true);
+    });
+
+  });
+});

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -1,242 +1,82 @@
 import History from "../src/scripts/game/vocabulary/history";
 
 describe("History()", () => {
+
+  describe("add()", () => {
+    it("adds the already confirmed entry to the current round's cache", () => {
+      const history = History();
+      const beforeCache = history.test.getEntries();
+      const confirmedEntry = {
+        slug: "0",
+        japanese: {
+          reading: "ふくざつ",
+          word: "複雑"
+        },
+        english: [],
+      };
+      history.add(confirmedEntry);
+      const afterCache = history.test.getEntries();
+      expect(afterCache.length).toBe(beforeCache.length + 1);
+    });
+  });
+
   describe("check()", () => {
-    it("Checking an empty cache with a new word [Entry]", () => {
+    it("confirms the user's guess wasn't used in the current round", () => {
       const history = History();
-      const entry = {
-        slug: "slug1",
+      const addedEntry = {
+        slug: "1",
         japanese: {
-          reading: "あつい",
-          word: "熱い",
+          reading: "にほん",
+          word: "日本"
         },
-        english: []
+        english: [],
       };
-      expect(history.check(entry)).toBe(true);
-    });
-
-    it("Checking an empty cache with a new word [Vocab]", () => {
-      const history = History();
-      const entry = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "熱い",
-        Definition: "hot"
-      };
-      expect(history.check(entry)).toBe(true);
-    });
-
-    it("Checking cache with the same exact word [Entry, Entry]", () => {
-      const history = History();
-      const entry = {
-        slug: "slug1",
+      const guess = {
+        slug: "0",
         japanese: {
-          reading: "あつい",
-          word: "熱い",
+          reading: "ふくざつ",
+          word: "複雑"
         },
-        english: []
+        english: [],
       };
-      history.add(entry);
-      expect(history.check(entry)).toBe(false);
+      history.add(addedEntry);
+      expect(history.check(guess)).toBe(true);
     });
 
-    it("Checking cache with the same exact word [Vocab, Vocab]", () => {
+    it("confirms the user's guess was already used in the current round", () => {
       const history = History();
-      const entry = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "熱い",
-        Definition: "hot"
-      };
-      history.add(entry);
-      expect(history.check(entry)).toBe(false);
-    });
-
-    it("Checking cache with the same exact word [Entry, Vocab]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
+      const addedEntry = {
+        slug: "1",
         japanese: {
-          reading: "あつい",
-          word: "熱い",
+          reading: "にほん",
+          word: "日本"
         },
-        english: []
+        english: [],
       };
-      history.add(entry1);
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "熱い",
-        Definition: "hot"
-      };
-      expect(history.check(entry2)).toBe(false);
+      history.add(addedEntry);
+      expect(history.check(addedEntry)).toBe(false);
     });
+  });
 
-    it("Checking cache with the same exact word [Vocab, Entry]", () => {
+  describe("clear()", () => {
+    it("completely empties out the cache", () => {
       const history = History();
-      const entry1 = {
-        slug: "slug1",
+      const confirmedEntry = {
+        slug: "0",
         japanese: {
-          reading: "あつい",
-          word: "熱い",
+          reading: "ふくざつ",
+          word: "複雑"
         },
-        english: []
+        english: [],
       };
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "熱い",
-        Definition: "hot"
-      };
-      history.add(entry2);
-      expect(history.check(entry1)).toBe(false);
-    });
 
-    it("Checking cache with a word with the same reading but not kanji [Entry, Vocab]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
-        japanese: {
-          reading: "あつい",
-          word: "熱い",
-        },
-        english: []
-      };
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "暑い",
-        Definition: "thick"
-      };
-      history.add(entry1);
-      expect(history.check(entry2)).toBe(true);
-    });
+      history.add(confirmedEntry);
+      const beforeCache = history.test.getEntries();
+      history.clear();
+      const afterCache = history.test.getEntries();
 
-    it("Checking cache with a word with the same reading but not kanji [Vocab, Entry]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
-        japanese: {
-          reading: "あつい",
-          word: "熱い",
-        },
-        english: []
-      };
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "暑い",
-        Definition: "thick"
-      };
-      history.add(entry2);
-      expect(history.check(entry1)).toBe(true);
+      expect(beforeCache.length).toBe(1);
+      expect(afterCache.length).toBe(0);
     });
-
-    it("Checking cache with a word with the same reading but one w/o kanji [Vocab, Entry]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
-        japanese: {
-          reading: "あつい",
-          word: "熱い",
-        },
-        english: []
-      };
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "",
-        Definition: "thick"
-      };
-      history.add(entry2);
-      expect(history.check(entry1)).toBe(true);
-    });
-
-    it("Checking cache with a word the same reading but both w/o kanji [Vocab, Entry]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
-        japanese: {
-          reading: "あつい",
-          word: "",
-        },
-        english: []
-      };
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "",
-        Definition: "thick"
-      };
-      history.add(entry2);
-      expect(history.check(entry1)).toBe(true);
-    });
-
-    it("Checking cache via slug [Entry, Entry]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
-        japanese: {
-          reading: "あつい",
-          word: "",
-        },
-        english: []
-      };
-      history.add(entry1);
-      expect(history.check(entry1)).toBe(false);
-    });
-
-    it("Checking cache via id [Vocab, Vocab]", () => {
-      const history = History();
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "",
-        Definition: "thick"
-      };
-      history.add(entry2);
-      expect(history.check(entry2)).toBe(false);
-    });
-
-    it("Checking cache via id [Entry, Vocab]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
-        japanese: {
-          reading: "あつい",
-          word: "",
-        },
-        english: []
-      };
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "",
-        Definition: "thick"
-      };
-      history.add(entry1);
-      expect(history.check(entry2)).toBe(true);
-    });
-
-    it("Checking cache via id [Vocab, Entry]", () => {
-      const history = History();
-      const entry1 = {
-        slug: "slug1",
-        japanese: {
-          reading: "あつい",
-          word: "",
-        },
-        english: []
-      };
-      const entry2 = {
-        ID: "id1",
-        Kana: "あつい",
-        Kanji: "",
-        Definition: "thick"
-      };
-      history.add(entry2);
-      expect(history.check(entry1)).toBe(true);
-    });
-
   });
 });

--- a/tests/vocab.test.ts
+++ b/tests/vocab.test.ts
@@ -203,124 +203,156 @@ describe("Vocab tests", () => {
     });
   });
 
-  // describe("validateResponse()", () => {
-  //   it("returns a Rejected Promise bc input wasn't found / doesn't match", async () => {
-  //     const currentWord = "なんでも";
-  //     const response = {
-  //       found: false,
-  //       entry: {
-  //         reading: "",
-  //         word: ""
-  //       }
-  //     };
-  //     return validateResponse(response, currentWord)
-  //       .catch(err =>
-  //         expect(err).toEqual(Error("No exact matches in the Joshi dictionary"))
-  //       );
-  //   });
+  describe("validateResponse()", () => {
+    it("returns a Rejected Promise bc input wasn't found / doesn't match", async () => {
+      const currentWord = "なんでも";
+      const response = {
+        found: false,
+        entry: {
+          slug: "",
+          japanese: {
+            reading: "",
+            word: ""
+          },
+          english: []
+        }
+      };
+      return validateResponse(response, currentWord)
+        .catch(err =>
+          expect(err).toEqual(Error("No exact matches in the Joshi dictionary"))
+        );
+    });
 
-  //   describe("returns a Rejected Promise bc of invalid input", () => {
-  //     it("ん", () => {
-  //       const currentWord = "みず";
-  //       const response = {
-  //         found: true,
-  //         entry: {
-  //           reading: "みずん",
-  //           word: ""
-  //         }
-  //       };
-  //       return validateResponse(response, currentWord)
-  //         .catch(err =>
-  //           expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
-  //         );
-  //     });
+    describe("returns a Rejected Promise bc of invalid input", () => {
+      it("ん", () => {
+        const currentWord = "みず";
+        const response = {
+          found: true,
+          entry: {
+            slug: "",
+            japanese: {
+              reading: "みずん",
+              word: ""
+            },
+            english: []
+          }
+        };
+        return validateResponse(response, currentWord)
+          .catch(err =>
+            expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
+          );
+      });
 
-  //     it("～", () => {
-  //       const currentWord = "みず";
-  //       const response = {
-  //         found: true,
-  //         entry: {
-  //           reading: "みず～",
-  //           word: ""
-  //         }
-  //       };
-  //       return validateResponse(response, currentWord)
-  //         .catch(err =>
-  //           expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
-  //         );
-  //     });
-  //   })
+      it("～", () => {
+        const currentWord = "みず";
+        const response = {
+          found: true,
+          entry: {
+            slug: "",
+            japanese: {
+              reading: "みず～",
+              word: ""
+            },
+            english: []
+          }
+        };
+        return validateResponse(response, currentWord)
+          .catch(err =>
+            expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
+          );
+      });
+    })
 
-  //   describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
-  //     it("みず --> すてき", async () => {
-  //       const currentWord = "みず";
-  //       const response = {
-  //         found: true,
-  //         entry: {
-  //           reading: "すてき",
-  //           word: "素敵"
-  //         }
-  //       };
-  //       return validateResponse(response, currentWord)
-  //         .catch(err =>
-  //           expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
-  //         );
-  //     });
+    describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
+      it("みず --> すてき", async () => {
+        const currentWord = "みず";
+        const response = {
+          found: true,
+          entry: {
+            slug: "",
+            japanese: {
+              reading: "すてき",
+              word: "素敵"
+            },
+            english: []
+          }
+        };
+        return validateResponse(response, currentWord)
+          .catch(err =>
+            expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
+          );
+      });
 
-  //     it("みず --> ～まで", async () => {
-  //       const currentWord = "みず";
-  //       const response = {
-  //         found: true,
-  //         entry: {
-  //           reading: "～まで",
-  //           word: ""
-  //         }
-  //       };
-  //       return validateResponse(response, currentWord)
-  //         .catch(err =>
-  //           expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
-  //         );
-  //     });
-  //   });
+      it("みず --> ～まで", async () => {
+        const currentWord = "みず";
+        const response = {
+          found: true,
+          entry: {
+            slug: "",
+            japanese: {
+              reading: "～まで",
+              word: ""
+            },
+            english: []
+          }
+        };
+        return validateResponse(response, currentWord)
+          .catch(err =>
+            expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
+          );
+      });
+    });
 
-  //   describe("returns Resolved Promise", () => {
-  //     it("みず --> ズルい", async () => {
-  //       const currentWord = "みず";
-  //       const response = {
-  //         found: true,
-  //         entry: {
-  //           reading: "ズルい",
-  //           word: ""
-  //         }
-  //       };
-  //       await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
-  //     });
+    describe("returns Resolved Promise", () => {
+      it("みず --> ズルい", async () => {
+        const currentWord = "みず";
+        const response = {
+          found: true,
+          entry: {
+            slug: "",
+            japanese: {
+              reading: "ズルい",
+              word: ""
+            },
+            english: []
+          }
+        };
+        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+      });
 
-  //     it("ギリギリ --> 理想的", async () => {
-  //       const currentWord = "ギリギリ";
-  //       const response = {
-  //         found: true,
-  //         entry: {
-  //           reading: "りそうてき",
-  //           word: "理想的"
-  //         }
-  //       };
-  //       await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
-  //     });
+      it("ギリギリ --> 理想的", async () => {
+        const currentWord = "ギリギリ";
+        const response = {
+          found: true,
+          entry: {
+            slug: "",
+            japanese: {
+              reading: "りそうてき",
+              word: "理想的"
+            },
+            english: []
+          }
+        };
+        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+      });
 
-  //     it("わかりやすい --> 忙しい", async () => {
-  //       const currentWord = "わかりやすい";
-  //       const response = {
-  //         found: true,
-  //         entry: {
-  //           reading: "いそがしい",
-  //           word: "忙しい"
-  //         }
-  //       };
-  //       await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
-  //     });
-  //   });
-  // });
+      it("わかりやすい --> 忙しい", async () => {
+        const currentWord = "わかりやすい";
+        const response = {
+          found: true,
+          entry: {
+            slug: "",
+            japanese: {
+              reading: "いそがしい",
+              word: "忙しい"
+            },
+            english: []
+          }
+        };
+        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+      });
+    });
+  });
 
   describe("isValid()", () => {
     it("returns TRUE", () => {

--- a/tests/vocab.test.ts
+++ b/tests/vocab.test.ts
@@ -4,7 +4,7 @@ import * as helperAtoms from "../src/scripts/game/vocabulary/helper_atoms";
 const vocab = require("../vocab-n5.json");
 
 const { calcRandomNum, convertSmallChars, ensureHiragana, } = helperAtoms;
-const { selectChar, selectWord, } = helpers;
+const { compileVocabulary, selectChar, selectWord, } = helpers;
 const {
   isValid,
   startsWithLastChar,
@@ -60,6 +60,41 @@ describe("Vocab tests", () => {
           const selectWord = jest.spyOn(helpers, "selectWord");
           vocabInstance.nextWord();
           expect(selectWord).toHaveBeenCalled();
+        });
+      });
+    });
+  });
+
+  describe("helpers", () => {
+
+    describe("compileVocabulary()", () => {
+      const vocab1 = JSON.parse(JSON.stringify({
+        "あ": [{ Kana: "ああ" }, { Kana: "あつい" }],
+      }));
+      const vocab2 = JSON.parse(JSON.stringify({
+        "あ": [{ Kana: "あまり" }, { Kana: "あたたかい" }],
+        "い": [{ Kana: "いま" }],
+      }));
+
+      it("returns the response when 'vocab' is null", () => {
+        const vocab = null;
+        const resp = vocab1;
+        const result = compileVocabulary(resp, vocab);
+        expect(result).toEqual(resp);
+      });
+
+      it("returns consolidated vocab when 'vocab' isn't null", () => {
+        const vocab = vocab1;
+        const resp = vocab2;
+        const result = compileVocabulary(resp, vocab);
+        expect(result).toEqual({
+          "あ": [
+            { Kana: "ああ" },
+            { Kana: "あつい" },
+            { Kana: "あまり" },
+            { Kana: "あたたかい" }
+          ],
+          "い": [{ Kana: "いま" }],
         });
       });
     });
@@ -168,125 +203,124 @@ describe("Vocab tests", () => {
     });
   });
 
-  describe("validateResponse()", () => {
-    it("returns a Rejected Promise bc input wasn't found / doesn't match", async () => {
-      const currentWord = "なんでも";
-      const response = {
-        found: false,
-        entry: {
-          reading: "",
-          word: ""
-        }
-      };
-      return validateResponse(response, currentWord)
-        .catch(err =>
-          expect(err).toEqual(Error("No exact matches in the Joshi dictionary"))
-        );
-    });
+  // describe("validateResponse()", () => {
+  //   it("returns a Rejected Promise bc input wasn't found / doesn't match", async () => {
+  //     const currentWord = "なんでも";
+  //     const response = {
+  //       found: false,
+  //       entry: {
+  //         reading: "",
+  //         word: ""
+  //       }
+  //     };
+  //     return validateResponse(response, currentWord)
+  //       .catch(err =>
+  //         expect(err).toEqual(Error("No exact matches in the Joshi dictionary"))
+  //       );
+  //   });
 
-    describe("returns a Rejected Promise bc of invalid input", () => {
-      it("ん", () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            reading: "みずん",
-            word: ""
-          }
-        };
-        return validateResponse(response, currentWord)
-          .catch(err =>
-            expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
-          );
-      });
+  //   describe("returns a Rejected Promise bc of invalid input", () => {
+  //     it("ん", () => {
+  //       const currentWord = "みず";
+  //       const response = {
+  //         found: true,
+  //         entry: {
+  //           reading: "みずん",
+  //           word: ""
+  //         }
+  //       };
+  //       return validateResponse(response, currentWord)
+  //         .catch(err =>
+  //           expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
+  //         );
+  //     });
 
-      it("～", () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            reading: "みず～",
-            word: ""
-          }
-        };
-        return validateResponse(response, currentWord)
-          .catch(err =>
-            expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
-          );
-      });
-    })
+  //     it("～", () => {
+  //       const currentWord = "みず";
+  //       const response = {
+  //         found: true,
+  //         entry: {
+  //           reading: "みず～",
+  //           word: ""
+  //         }
+  //       };
+  //       return validateResponse(response, currentWord)
+  //         .catch(err =>
+  //           expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
+  //         );
+  //     });
+  //   })
 
-    describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
-      it("みず --> すてき", async () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            reading: "すてき",
-            word: "素敵"
-          }
-        };
-        return validateResponse(response, currentWord)
-          .catch(err =>
-            expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
-          );
-      });
+  //   describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
+  //     it("みず --> すてき", async () => {
+  //       const currentWord = "みず";
+  //       const response = {
+  //         found: true,
+  //         entry: {
+  //           reading: "すてき",
+  //           word: "素敵"
+  //         }
+  //       };
+  //       return validateResponse(response, currentWord)
+  //         .catch(err =>
+  //           expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
+  //         );
+  //     });
 
-      it("みず --> ～まで", async () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            reading: "～まで",
-            word: ""
-          }
-        };
-        return validateResponse(response, currentWord)
-          .catch(err =>
-            expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
-          );
-      });
-    });
+  //     it("みず --> ～まで", async () => {
+  //       const currentWord = "みず";
+  //       const response = {
+  //         found: true,
+  //         entry: {
+  //           reading: "～まで",
+  //           word: ""
+  //         }
+  //       };
+  //       return validateResponse(response, currentWord)
+  //         .catch(err =>
+  //           expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
+  //         );
+  //     });
+  //   });
 
-    describe("returns Resolved Promise", () => {
-      it("みず --> ズルい", async () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            reading: "ズルい",
-            word: ""
-          }
-        };
-        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
-      });
+  //   describe("returns Resolved Promise", () => {
+  //     it("みず --> ズルい", async () => {
+  //       const currentWord = "みず";
+  //       const response = {
+  //         found: true,
+  //         entry: {
+  //           reading: "ズルい",
+  //           word: ""
+  //         }
+  //       };
+  //       await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+  //     });
 
-      it("ギリギリ --> 理想的", async () => {
-        const currentWord = "ギリギリ";
-        const response = {
-          found: true,
-          entry: {
-            reading: "りそうてき",
-            word: "理想的"
-          }
-        };
-        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
-      });
+  //     it("ギリギリ --> 理想的", async () => {
+  //       const currentWord = "ギリギリ";
+  //       const response = {
+  //         found: true,
+  //         entry: {
+  //           reading: "りそうてき",
+  //           word: "理想的"
+  //         }
+  //       };
+  //       await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+  //     });
 
-      it("わかりやすい --> 忙しい", async () => {
-        const currentWord = "わかりやすい";
-        const response = {
-          found: true,
-          entry: {
-            reading: "いそがしい",
-            word: "忙しい"
-          }
-        };
-        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
-      });
-    });
-
-  });
+  //     it("わかりやすい --> 忙しい", async () => {
+  //       const currentWord = "わかりやすい";
+  //       const response = {
+  //         found: true,
+  //         entry: {
+  //           reading: "いそがしい",
+  //           word: "忙しい"
+  //         }
+  //       };
+  //       await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+  //     });
+  //   });
+  // });
 
   describe("isValid()", () => {
     it("returns TRUE", () => {

--- a/tests/vocab.test.ts
+++ b/tests/vocab.test.ts
@@ -436,21 +436,21 @@ describe("Vocab tests", () => {
     describe("selectWord()", () => {
       it("returns 'null' if all options aren't valid", () => {
         const availableWords = [
-          { Kana: "かんぜん", Kanji: "完全", Definition: "" },
-          { Kana: "たぶん", Kanji: "多分", Definition: "" },
-          { Kana: "カテゴリー", Kanji: "", Definition: "" },
-          { Kana: "ね～", Kanji: "", Definition: "" },
+          { ID: "1", Kana: "かんぜん", Kanji: "完全", Definition: "" },
+          { ID: "2", Kana: "たぶん", Kanji: "多分", Definition: "" },
+          { ID: "3", Kana: "カテゴリー", Kanji: "", Definition: "" },
+          { ID: "4", Kana: "ね～", Kanji: "", Definition: "" },
         ];
         const result = selectWord(availableWords);
         expect(result).toBe(null);
       });
 
       it("returns the sole valid option", () => {
-        const validOption = { Kana: "ふくざつ", Kanji: "複雑", Definition: "" };
+        const validOption = { ID: "0", Kana: "ふくざつ", Kanji: "複雑", Definition: "" };
         const availableWords = [
-          { Kana: "かんぜん", Kanji: "完全", Definition: "" },
-          { Kana: "たぶん", Kanji: "多分", Definition: "" },
-          { Kana: "カテゴリー", Kanji: "", Definition: "" },
+          { ID: "1", Kana: "かんぜん", Kanji: "完全", Definition: "" },
+          { ID: "2", Kana: "たぶん", Kanji: "多分", Definition: "" },
+          { ID: "3", Kana: "カテゴリー", Kanji: "", Definition: "" },
           validOption
         ];
         const result = selectWord(availableWords);
@@ -516,10 +516,10 @@ describe("Vocab tests", () => {
   describe.skip("random tests [failure possibility]", () => {
     it("[selectWord] selects a random word from a list of words", () => {
       const availableWords = [
-        { Kana: "かなり", Kanji: "", Definition: "" },
-        { Kana: "かならず", Kanji: "必ず", Definition: "" },
-        { Kana: "かっこいい", Kanji: "", Definition: "" },
-        { Kana: "かつ", Kanji: "勝つ", Definition: "" },
+        { ID: "1", Kana: "かなり", Kanji: "", Definition: "" },
+        { ID: "2", Kana: "かならず", Kanji: "必ず", Definition: "" },
+        { ID: "3", Kana: "かっこいい", Kanji: "", Definition: "" },
+        { ID: "4", Kana: "かつ", Kanji: "勝つ", Definition: "" },
       ];
       const result1 = selectWord(availableWords);
       const result2 = selectWord(availableWords);

--- a/tests/vocab.test.ts
+++ b/tests/vocab.test.ts
@@ -98,140 +98,119 @@ describe("Vocab tests", () => {
         });
       });
     });
-  });
 
-  describe("selectChar()", () => {
-    it("calls ensureHiragana()", () => {
-      const spy = jest.spyOn(helperAtoms, "ensureHiragana");
-      selectChar(vocab, "か");
-      expect(spy).toHaveBeenCalled();
-    });
-  });
-
-  describe("validateQuery()", () => {
-    describe("returns a Rejected Promise bc input isn't Japanese", () => {
-      it("english", async () => {
-        await expect(
-          validateQuery("なんでも", "english")
-        ).rejects.toEqual(
-          Error("Not Japanese")
-        );
-      });
-
-      it("12345", async () => {
-        await expect(
-          validateQuery("なんでも", "12345")
-        ).rejects.toEqual(
-          Error("Not Japanese")
-        );
-      });
-
-      it("!@%", async () => {
-        await expect(
-          validateQuery("なんでも", "!@%")
-        ).rejects.toEqual(
-          Error("Not Japanese")
-        );
+    describe("selectChar()", () => {
+      it("calls ensureHiragana()", () => {
+        const spy = jest.spyOn(helperAtoms, "ensureHiragana");
+        selectChar(vocab, "か");
+        expect(spy).toHaveBeenCalled();
       });
     });
 
-    describe("returns a Rejected Promise bc of invalid input", () => {
-      it("ーーーーー", async () => {
-        await expect(
-          validateQuery("なんでも", "ーーーーー")).rejects.toEqual(
-            Error("Last character is unacceptable")
+    describe("validateQuery()", () => {
+      describe("returns a Rejected Promise bc input isn't Japanese", () => {
+        it("english", async () => {
+          await expect(
+            validateQuery("なんでも", "english")
+          ).rejects.toEqual(
+            Error("Not Japanese")
           );
-      });
+        });
 
-      it("そんな～", async () => {
-        await expect(
-          validateQuery("なんでも", "そんな～")).rejects.toEqual(
-            Error("Last character is unacceptable")
+        it("12345", async () => {
+          await expect(
+            validateQuery("なんでも", "12345")
+          ).rejects.toEqual(
+            Error("Not Japanese")
           );
-      });
+        });
 
-      it("しんねん", async () => {
-        await expect(
-          validateQuery("なんでも", "しんねん")).rejects.toEqual(
-            Error("Last character is unacceptable")
+        it("!@%", async () => {
+          await expect(
+            validateQuery("なんでも", "!@%")
+          ).rejects.toEqual(
+            Error("Not Japanese")
           );
+        });
+      });
+
+      describe("returns a Rejected Promise bc of invalid input", () => {
+        it("ーーーーー", async () => {
+          await expect(
+            validateQuery("なんでも", "ーーーーー")).rejects.toEqual(
+              Error("Last character is unacceptable")
+            );
+        });
+
+        it("そんな～", async () => {
+          await expect(
+            validateQuery("なんでも", "そんな～")).rejects.toEqual(
+              Error("Last character is unacceptable")
+            );
+        });
+
+        it("しんねん", async () => {
+          await expect(
+            validateQuery("なんでも", "しんねん")).rejects.toEqual(
+              Error("Last character is unacceptable")
+            );
+        });
+      });
+
+      describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
+        it("むてき", async () => {
+          await expect(
+            validateQuery("なんでも", "むてき")
+          ).rejects.toEqual(
+            Error("User input's first character doesn't match given word's last character")
+          );
+        });
+
+        it("ったく", async () => {
+          await expect(
+            validateQuery("なんでも", "ったく")
+          ).rejects.toEqual(
+            Error("User input's first character doesn't match given word's last character")
+          );
+        });
+      });
+
+      describe("returns Resolved Promise", () => {
+        it("むし", async () => {
+          await expect(
+            validateQuery("すすむ", "むし")
+          ).resolves.toEqual(
+            "No issues"
+          );
+        });
+
+        it("うらやましい", async () => {
+          await expect(
+            validateQuery("じゆう", "うらやましい")
+          ).resolves.toEqual(
+            "No issues"
+          );
+        });
+
+        it("るす", async () => {
+          await expect(
+            validateQuery("たべる", "るす")
+          ).resolves.toEqual(
+            "No issues"
+          );
+        });
       });
     });
 
-    describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
-      it("むてき", async () => {
-        await expect(
-          validateQuery("なんでも", "むてき")
-        ).rejects.toEqual(
-          Error("User input's first character doesn't match given word's last character")
-        );
-      });
-
-      it("ったく", async () => {
-        await expect(
-          validateQuery("なんでも", "ったく")
-        ).rejects.toEqual(
-          Error("User input's first character doesn't match given word's last character")
-        );
-      });
-    });
-
-    describe("returns Resolved Promise", () => {
-      it("むし", async () => {
-        await expect(
-          validateQuery("すすむ", "むし")
-        ).resolves.toEqual(
-          "No issues"
-        );
-      });
-
-      it("うらやましい", async () => {
-        await expect(
-          validateQuery("じゆう", "うらやましい")
-        ).resolves.toEqual(
-          "No issues"
-        );
-      });
-
-      it("るす", async () => {
-        await expect(
-          validateQuery("たべる", "るす")
-        ).resolves.toEqual(
-          "No issues"
-        );
-      });
-    });
-  });
-
-  describe("validateResponse()", () => {
-    it("returns a Rejected Promise bc input wasn't found / doesn't match", async () => {
-      const currentWord = "なんでも";
-      const response = {
-        found: false,
-        entry: {
-          slug: "",
-          japanese: {
-            reading: "",
-            word: ""
-          },
-          english: []
-        }
-      };
-      return validateResponse(response, currentWord)
-        .catch(err =>
-          expect(err).toEqual(Error("No exact matches in the Joshi dictionary"))
-        );
-    });
-
-    describe("returns a Rejected Promise bc of invalid input", () => {
-      it("ん", () => {
-        const currentWord = "みず";
+    describe("validateResponse()", () => {
+      it("returns a Rejected Promise bc input wasn't found / doesn't match", async () => {
+        const currentWord = "なんでも";
         const response = {
-          found: true,
+          found: false,
           entry: {
             slug: "",
             japanese: {
-              reading: "みずん",
+              reading: "",
               word: ""
             },
             english: []
@@ -239,277 +218,300 @@ describe("Vocab tests", () => {
         };
         return validateResponse(response, currentWord)
           .catch(err =>
-            expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
+            expect(err).toEqual(Error("No exact matches in the Joshi dictionary"))
           );
       });
 
-      it("～", () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            slug: "",
-            japanese: {
-              reading: "みず～",
-              word: ""
-            },
-            english: []
-          }
-        };
-        return validateResponse(response, currentWord)
-          .catch(err =>
-            expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
-          );
-      });
-    })
+      describe("returns a Rejected Promise bc of invalid input", () => {
+        it("ん", () => {
+          const currentWord = "みず";
+          const response = {
+            found: true,
+            entry: {
+              slug: "",
+              japanese: {
+                reading: "みずん",
+                word: ""
+              },
+              english: []
+            }
+          };
+          return validateResponse(response, currentWord)
+            .catch(err =>
+              expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
+            );
+        });
 
-    describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
-      it("みず --> すてき", async () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            slug: "",
-            japanese: {
-              reading: "すてき",
-              word: "素敵"
-            },
-            english: []
-          }
-        };
-        return validateResponse(response, currentWord)
-          .catch(err =>
-            expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
-          );
-      });
+        it("～", () => {
+          const currentWord = "みず";
+          const response = {
+            found: true,
+            entry: {
+              slug: "",
+              japanese: {
+                reading: "みず～",
+                word: ""
+              },
+              english: []
+            }
+          };
+          return validateResponse(response, currentWord)
+            .catch(err =>
+              expect(err).toEqual(Error("User's kanji input ends with unacceptable character"))
+            );
+        });
+      })
 
-      it("みず --> ～まで", async () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            slug: "",
-            japanese: {
-              reading: "～まで",
-              word: ""
-            },
-            english: []
-          }
-        };
-        return validateResponse(response, currentWord)
-          .catch(err =>
-            expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
-          );
-      });
-    });
+      describe("returns a Rejected Promise bc word doesn't start with the previous' last character", () => {
+        it("みず --> すてき", async () => {
+          const currentWord = "みず";
+          const response = {
+            found: true,
+            entry: {
+              slug: "",
+              japanese: {
+                reading: "すてき",
+                word: "素敵"
+              },
+              english: []
+            }
+          };
+          return validateResponse(response, currentWord)
+            .catch(err =>
+              expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
+            );
+        });
 
-    describe("returns Resolved Promise", () => {
-      it("みず --> ズルい", async () => {
-        const currentWord = "みず";
-        const response = {
-          found: true,
-          entry: {
-            slug: "",
-            japanese: {
-              reading: "ズルい",
-              word: ""
-            },
-            english: []
-          }
-        };
-        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
-      });
-
-      it("ギリギリ --> 理想的", async () => {
-        const currentWord = "ギリギリ";
-        const response = {
-          found: true,
-          entry: {
-            slug: "",
-            japanese: {
-              reading: "りそうてき",
-              word: "理想的"
-            },
-            english: []
-          }
-        };
-        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+        it("みず --> ～まで", async () => {
+          const currentWord = "みず";
+          const response = {
+            found: true,
+            entry: {
+              slug: "",
+              japanese: {
+                reading: "～まで",
+                word: ""
+              },
+              english: []
+            }
+          };
+          return validateResponse(response, currentWord)
+            .catch(err =>
+              expect(err).toEqual(Error("User's kanji input's first character doesn't match given word's last character"))
+            );
+        });
       });
 
-      it("わかりやすい --> 忙しい", async () => {
-        const currentWord = "わかりやすい";
-        const response = {
-          found: true,
-          entry: {
-            slug: "",
-            japanese: {
-              reading: "いそがしい",
-              word: "忙しい"
-            },
-            english: []
-          }
-        };
-        await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+      describe("returns Resolved Promise", () => {
+        it("みず --> ズルい", async () => {
+          const currentWord = "みず";
+          const response = {
+            found: true,
+            entry: {
+              slug: "",
+              japanese: {
+                reading: "ズルい",
+                word: ""
+              },
+              english: []
+            }
+          };
+          await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+        });
+
+        it("ギリギリ --> 理想的", async () => {
+          const currentWord = "ギリギリ";
+          const response = {
+            found: true,
+            entry: {
+              slug: "",
+              japanese: {
+                reading: "りそうてき",
+                word: "理想的"
+              },
+              english: []
+            }
+          };
+          await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+        });
+
+        it("わかりやすい --> 忙しい", async () => {
+          const currentWord = "わかりやすい";
+          const response = {
+            found: true,
+            entry: {
+              slug: "",
+              japanese: {
+                reading: "いそがしい",
+                word: "忙しい"
+              },
+              english: []
+            }
+          };
+          await expect(validateResponse(response, currentWord)).resolves.toBe("No issues");
+        });
       });
     });
-  });
 
-  describe("isValid()", () => {
-    it("returns TRUE", () => {
-      expect(isValid("しごと")).toBe(true);
-      expect(isValid("フォーク")).toBe(true);
-      expect(isValid("就活")).toBe(true);
-    });
-    it("returns FALSE", () => {
-      expect(isValid("ルーター")).toBe(false);
-      expect(isValid("え～")).toBe(false);
-      expect(isValid("かんたん")).toBe(false);
-    });
-
-  });
-
-  describe("startsWithLastChar()", () => {
-    it("returns TRUE for にほんご --> ごぜん", () => {
-      const prevWord = "にほんご";
-      const guessWord = "ごぜん";
-      const result = startsWithLastChar(prevWord, guessWord);
-      expect(result).toBe(true);
+    describe("isValid()", () => {
+      it("returns TRUE", () => {
+        expect(isValid("しごと")).toBe(true);
+        expect(isValid("フォーク")).toBe(true);
+        expect(isValid("就活")).toBe(true);
+      });
+      it("returns FALSE", () => {
+        expect(isValid("ルーター")).toBe(false);
+        expect(isValid("え～")).toBe(false);
+        expect(isValid("かんたん")).toBe(false);
+      });
     });
 
-    it("returns TRUE for ふくざつ --> つくりかた", () => {
-      const prevWord = "ふくざつ";
-      const guessWord = "つくりかた";
-      const result = startsWithLastChar(prevWord, guessWord);
-      expect(result).toBe(true);
-    });
-
-    it("returns TRUE for かのじょ --> よやく", () => {
-      const prevWord = "かのじょ";
-      const guessWord = "よやく";
-      const result = startsWithLastChar(prevWord, guessWord);
-      expect(result).toBe(true);
-    });
-
-    it("returns TRUE for アメリカ --> かなり", () => {
-      const prevWord = "アメリカ";
-      const guessWord = "かなり";
-      const result = startsWithLastChar(prevWord, guessWord);
-      expect(result).toBe(true);
-    });
-
-    describe("returns TRUE for kanji guessWords", () => {
-      it("仕方ない", () => {
-        const prevWord = "なんでも";
-        const guessWord = "仕方ない";
+    describe("startsWithLastChar()", () => {
+      it("returns TRUE for にほんご --> ごぜん", () => {
+        const prevWord = "にほんご";
+        const guessWord = "ごぜん";
         const result = startsWithLastChar(prevWord, guessWord);
         expect(result).toBe(true);
       });
 
-      it("色々", () => {
-        const prevWord = "なんでも";
-        const guessWord = "色々";
+      it("returns TRUE for ふくざつ --> つくりかた", () => {
+        const prevWord = "ふくざつ";
+        const guessWord = "つくりかた";
         const result = startsWithLastChar(prevWord, guessWord);
         expect(result).toBe(true);
       });
 
-      it("日本", () => {
-        const prevWord = "なんでも";
-        const guessWord = "日本";
+      it("returns TRUE for かのじょ --> よやく", () => {
+        const prevWord = "かのじょ";
+        const guessWord = "よやく";
         const result = startsWithLastChar(prevWord, guessWord);
         expect(result).toBe(true);
       });
-    })
 
-    it("returns FALSE for つくりかた --> つくりもの", () => {
-      const prevWord = "つくりかた";
-      const guessWord = "つくりもの";
-      const result = startsWithLastChar(prevWord, guessWord);
-      expect(result).toBe(false);
+      it("returns TRUE for アメリカ --> かなり", () => {
+        const prevWord = "アメリカ";
+        const guessWord = "かなり";
+        const result = startsWithLastChar(prevWord, guessWord);
+        expect(result).toBe(true);
+      });
+
+      describe("returns TRUE for kanji guessWords", () => {
+        it("仕方ない", () => {
+          const prevWord = "なんでも";
+          const guessWord = "仕方ない";
+          const result = startsWithLastChar(prevWord, guessWord);
+          expect(result).toBe(true);
+        });
+
+        it("色々", () => {
+          const prevWord = "なんでも";
+          const guessWord = "色々";
+          const result = startsWithLastChar(prevWord, guessWord);
+          expect(result).toBe(true);
+        });
+
+        it("日本", () => {
+          const prevWord = "なんでも";
+          const guessWord = "日本";
+          const result = startsWithLastChar(prevWord, guessWord);
+          expect(result).toBe(true);
+        });
+      })
+
+      it("returns FALSE for つくりかた --> つくりもの", () => {
+        const prevWord = "つくりかた";
+        const guessWord = "つくりもの";
+        const result = startsWithLastChar(prevWord, guessWord);
+        expect(result).toBe(false);
+      });
+
+      it("returns FALSE for ルーター --> たてもの", () => {
+        const prevWord = "ルーター";
+        const guessWord = "たてもの";
+        const result = startsWithLastChar(prevWord, guessWord);
+        expect(result).toBe(false);
+      });
     });
 
-    it("returns FALSE for ルーター --> たてもの", () => {
-      const prevWord = "ルーター";
-      const guessWord = "たてもの";
-      const result = startsWithLastChar(prevWord, guessWord);
-      expect(result).toBe(false);
-    });
+    describe("selectWord()", () => {
+      it("returns 'null' if all options aren't valid", () => {
+        const availableWords = [
+          { Kana: "かんぜん", Kanji: "完全", Definition: "" },
+          { Kana: "たぶん", Kanji: "多分", Definition: "" },
+          { Kana: "カテゴリー", Kanji: "", Definition: "" },
+          { Kana: "ね～", Kanji: "", Definition: "" },
+        ];
+        const result = selectWord(availableWords);
+        expect(result).toBe(null);
+      });
 
+      it("returns the sole valid option", () => {
+        const validOption = { Kana: "ふくざつ", Kanji: "複雑", Definition: "" };
+        const availableWords = [
+          { Kana: "かんぜん", Kanji: "完全", Definition: "" },
+          { Kana: "たぶん", Kanji: "多分", Definition: "" },
+          { Kana: "カテゴリー", Kanji: "", Definition: "" },
+          validOption
+        ];
+        const result = selectWord(availableWords);
+        expect(result).toEqual(validOption);
+      });
+
+      it("returns 'null' if there are no options", () => {
+        const availableWords = [];
+        const result = selectWord(availableWords);
+        expect(result).toBe(null);
+      });
+    });
   });
 
-  describe("ensureHiragana()", () => {
-    it("detects katakana and converts to corresponding hiragana", () => {
-      expect(ensureHiragana("カ")).toBe("か");
-      expect(ensureHiragana("フ")).toBe("ふ");
-      expect(ensureHiragana("ヲ")).toBe("を");
-      expect(ensureHiragana("ユ")).toBe("ゆ");
-      expect(ensureHiragana("ン")).toBe("ん");
+  describe("helper atoms", () => {
+
+    describe("ensureHiragana()", () => {
+      it("detects katakana and converts to corresponding hiragana", () => {
+        expect(ensureHiragana("カ")).toBe("か");
+        expect(ensureHiragana("フ")).toBe("ふ");
+        expect(ensureHiragana("ヲ")).toBe("を");
+        expect(ensureHiragana("ユ")).toBe("ゆ");
+        expect(ensureHiragana("ン")).toBe("ん");
+      });
+      it("returns same character if already hiragana", () => {
+        expect(ensureHiragana("ち")).toBe("ち");
+        expect(ensureHiragana("た")).toBe("た");
+        expect(ensureHiragana("り")).toBe("り");
+        expect(ensureHiragana("ー")).toBe("ー");
+        expect(ensureHiragana("～")).toBe("～");
+      });
     });
-    it("returns same character if already hiragana", () => {
-      expect(ensureHiragana("ち")).toBe("ち");
-      expect(ensureHiragana("た")).toBe("た");
-      expect(ensureHiragana("り")).toBe("り");
-      expect(ensureHiragana("ー")).toBe("ー");
-      expect(ensureHiragana("～")).toBe("～");
+
+    describe("convertSmallChars()", () => {
+      describe("for words ending in certain 'small' characters", () => {
+        it("converts 'ょ' to 'よ'", () => {
+          expect(convertSmallChars("かのじょ")).toBe("よ");
+        });
+        it("converts 'ゃ' to 'や'", () => {
+          expect(convertSmallChars("じゃ")).toBe("や");
+        });
+        it("converts 'ゅ' to 'ゆ'", () => {
+          expect(convertSmallChars("しゅ")).toBe("ゆ");
+        });
+        it("converts 'っ' to 'つ'", () => {
+          expect(convertSmallChars("ふっ")).toBe("つ");
+        });
+        it("converts 'ぇ' to 'え'", () => {
+          expect(convertSmallChars("ちぇ")).toBe("え");
+        });
+      });
+
+      describe("for words ending with regular characters", () => {
+        it("returns the word's last character as-is, unchanged", () => {
+          const word = "すごい";
+          expect(convertSmallChars(word)).toBe("い");
+        });
+      });
     });
   });
 
-  describe("convertSmallChars()", () => {
-    describe("for words ending in certain 'small' characters", () => {
-      it("converts 'ょ' to 'よ'", () => {
-        expect(convertSmallChars("かのじょ")).toBe("よ");
-      });
-      it("converts 'ゃ' to 'や'", () => {
-        expect(convertSmallChars("じゃ")).toBe("や");
-      });
-      it("converts 'ゅ' to 'ゆ'", () => {
-        expect(convertSmallChars("しゅ")).toBe("ゆ");
-      });
-      it("converts 'っ' to 'つ'", () => {
-        expect(convertSmallChars("ふっ")).toBe("つ");
-      });
-      it("converts 'ぇ' to 'え'", () => {
-        expect(convertSmallChars("ちぇ")).toBe("え");
-      });
-    });
-
-    describe("for words ending with regular characters", () => {
-      it("returns the word's last character as-is, unchanged", () => {
-        const word = "すごい";
-        expect(convertSmallChars(word)).toBe("い");
-      });
-    });
-  });
-
-  describe("selectWord()", () => {
-    it("returns 'null' if all options aren't valid", () => {
-      const availableWords = [
-        { Kana: "かんぜん", Kanji: "完全", Definition: "" },
-        { Kana: "たぶん", Kanji: "多分", Definition: "" },
-        { Kana: "カテゴリー", Kanji: "", Definition: "" },
-        { Kana: "ね～", Kanji: "", Definition: "" },
-      ];
-      const result = selectWord(availableWords);
-      expect(result).toBe(null);
-    });
-
-    it("returns the sole valid option", () => {
-      const validOption = { Kana: "ふくざつ", Kanji: "複雑", Definition: "" };
-      const availableWords = [
-        { Kana: "かんぜん", Kanji: "完全", Definition: "" },
-        { Kana: "たぶん", Kanji: "多分", Definition: "" },
-        { Kana: "カテゴリー", Kanji: "", Definition: "" },
-        validOption
-      ];
-      const result = selectWord(availableWords);
-      expect(result).toEqual(validOption);
-    });
-
-    it("returns 'null' if there are no options", () => {
-      const availableWords = [];
-      const result = selectWord(availableWords);
-      expect(result).toBe(null);
-    });
-  });
 
   describe.skip("random tests [failure possibility]", () => {
     it("[selectWord] selects a random word from a list of words", () => {

--- a/vocab-n3.json
+++ b/vocab-n3.json
@@ -1,0 +1,1146 @@
+{
+  "あ": [
+    {
+      "ID": "N3#1",
+      "Kana": "あかり",
+      "Kanji": "明かり",
+      "Definition": "light; illumination; glow; gleam"
+    },
+    {
+      "ID": "N3#2",
+      "Kana": "あける",
+      "Kanji": "明ける",
+      "Definition": "to dawn,to become daylight"
+    },
+    {
+      "ID": "N3#3",
+      "Kana": "あきらか",
+      "Kanji": "明らか",
+      "Definition": "clear; obvious"
+    },
+    {
+      "ID": "N3#4",
+      "Kana": "あくま",
+      "Kanji": "悪魔",
+      "Definition": "devil; demon; fiend; Satan"
+    },
+    {
+      "ID": "N3#5",
+      "Kana": "あんき",
+      "Kanji": "暗記",
+      "Definition": "memorization; learning by heart"
+    },
+    {
+      "ID": "N3#6",
+      "Kana": "あらた",
+      "Kanji": "新た",
+      "Definition": "new; fresh; novel"
+    },
+    {
+      "ID": "N3#7",
+      "Kana": "あらゆる",
+      "Kanji": "有らゆる",
+      "Definition": "all; every​"
+    },
+    {
+      "ID": "N3#8",
+      "Kana": "あつまり",
+      "Kanji": "集まり",
+      "Definition": "gathering; meeting; assembly; collection; attendance"
+    }
+  ],
+  "い": [
+    {
+      "ID": "N3#9",
+      "Kana": "いっち",
+      "Kanji": "一致",
+      "Definition": "agreement; union; match​; coincidence"
+    },
+    {
+      "ID": "N3#10",
+      "Kana": "いちじ",
+      "Kanji": "一時",
+      "Definition": "one o'clock"
+    },
+    {
+      "ID": "N3#11",
+      "Kana": "いがい",
+      "Kanji": "意外",
+      "Definition": "unexpected; surprising"
+    },
+    {
+      "ID": "N3#12",
+      "Kana": "いっか",
+      "Kanji": "一家",
+      "Definition": "a family; a household; a home; one's family; whole family"
+    },
+    {
+      "ID": "N3#13",
+      "Kana": "いまに",
+      "Kanji": "今に",
+      "Definition": "before long; even now"
+    },
+    {
+      "ID": "N3#14",
+      "Kana": "いまにも",
+      "Kanji": "今にも",
+      "Definition": "at any moment; at any minute; on the verge of"
+    },
+    {
+      "ID": "N3#15",
+      "Kana": "いっぱん",
+      "Kanji": "一般",
+      "Definition": "general; universal; ordinary; average; common"
+    },
+    {
+      "ID": "N3#16",
+      "Kana": "いっぽう",
+      "Kanji": "一方",
+      "Definition": "one (esp. of two); one way; the other direction; although"
+    },
+    {
+      "ID": "N3#17",
+      "Kana": "いっしょう",
+      "Kanji": "一生",
+      "Definition": "whole life; a lifetime; a generation"
+    },
+    {
+      "ID": "N3#18",
+      "Kana": "いっしゅ",
+      "Kanji": "一種",
+      "Definition": "species; kind; variety"
+    },
+    {
+      "ID": "N3#19",
+      "Kana": "いっしゅん",
+      "Kanji": "一瞬",
+      "Definition": "instant; moment; for an instant"
+    },
+    {
+      "ID": "N3#20",
+      "Kana": "いっそう",
+      "Kanji": "一層",
+      "Definition": "much more; still more; all the more; single layer; sooner; preferably​"
+    },
+    {
+      "ID": "N3#21",
+      "Kana": "いったい",
+      "Kanji": "一体",
+      "Definition": "(what) the heck; (why) in the world"
+    },
+    {
+      "ID": "N3#22",
+      "Kana": "いわゆる",
+      "Kanji": "所謂",
+      "Definition": "what is called; as it is called; the so-called; so to speak​"
+    }
+  ],
+  "う": [
+    {
+      "ID": "N3#23",
+      "Kana": "うけとる",
+      "Kanji": "受け取る",
+      "Definition": "to receive; to understand"
+    },
+    {
+      "ID": "N3#24",
+      "Kana": "うまい",
+      "Kanji": "上手い",
+      "Definition": "skillful; delicious"
+    },
+    {
+      "ID": "N3#25",
+      "Kana": "うれる",
+      "Kanji": "売れる",
+      "Definition": "to sell (well)"
+    }
+  ],
+  "え": [
+    {
+      "ID": "N3#26",
+      "Kana": "えん",
+      "Kanji": "円",
+      "Definition": "yen; Japanese monetary unit; circle"
+    }
+  ],
+  "お": [
+    {
+      "ID": "N3#27",
+      "Kana": "おひる",
+      "Kanji": "お昼",
+      "Definition": "lunch; midday; daytime"
+    },
+    {
+      "ID": "N3#28",
+      "Kana": "おさめる",
+      "Kanji": "収める",
+      "Definition": "to supply; to dedicate; to make an offering; to pay"
+    }
+  ],
+  "か": [
+    {
+      "ID": "N3#29",
+      "Kana": "かがく",
+      "Kanji": "化学",
+      "Definition": "chemistry"
+    },
+    {
+      "ID": "N3#30",
+      "Kana": "かいいん",
+      "Kanji": "会員",
+      "Definition": "member"
+    },
+    {
+      "ID": "N3#31",
+      "Kana": "かいがい",
+      "Kanji": "海外",
+      "Definition": "foreign; abroad; overseas"
+    },
+    {
+      "ID": "N3#32",
+      "Kana": "かいごう",
+      "Kanji": "会合",
+      "Definition": "meeting; assembly; gathering; association"
+    },
+    {
+      "ID": "N3#33",
+      "Kana": "かいけい",
+      "Kanji": "会計",
+      "Definition": "finance; account; treasurer; bill"
+    },
+    {
+      "ID": "N3#34",
+      "Kana": "かいし",
+      "Kanji": "開始",
+      "Definition": "start; commencement; beginning; initiation​"
+    },
+    {
+      "ID": "N3#35",
+      "Kana": "かもく",
+      "Kanji": "科目",
+      "Definition": "(school) subject; curriculum; course"
+    }
+  ],
+  "が": [
+    {
+      "ID": "N3#36",
+      "Kana": "がいこう",
+      "Kanji": "外交",
+      "Definition": "diplomacy"
+    },
+    {
+      "ID": "N3#37",
+      "Kana": "がいしゅつ",
+      "Kanji": "外出",
+      "Definition": "going out; outing; leaving (one's home, office, etc.)"
+    },
+    {
+      "ID": "N3#38",
+      "Kana": "がっき",
+      "Kanji": "学期",
+      "Definition": "school term; semester"
+    },
+    {
+      "ID": "N3#39",
+      "Kana": "がくもん",
+      "Kanji": "学問",
+      "Definition": "scholarship; study; learning"
+    },
+    {
+      "ID": "N3#40",
+      "Kana": "がくしゃ",
+      "Kanji": "学者",
+      "Definition": "scholar"
+    },
+    {
+      "ID": "N3#41",
+      "Kana": "がくしゅう",
+      "Kanji": "学習",
+      "Definition": "study; learning; tutorial"
+    }
+  ],
+  "き": [
+    {
+      "ID": "N3#42",
+      "Kana": "きほん",
+      "Kanji": "基本",
+      "Definition": "basics; fundamentals; basis; foundation"
+    },
+    {
+      "ID": "N3#43",
+      "Kana": "きじ",
+      "Kanji": "記事",
+      "Definition": "article; news story; report; account"
+    },
+    {
+      "ID": "N3#44",
+      "Kana": "きみ",
+      "Kanji": "気味",
+      "Definition": "sensation; feeling​; tendency"
+    },
+    {
+      "ID": "N3#45",
+      "Kana": "きねん",
+      "Kanji": "記念",
+      "Definition": "commemoration; celebration; honoring the memory of something"
+    },
+    {
+      "ID": "N3#46",
+      "Kana": "きにいる",
+      "Kanji": "気に入る",
+      "Definition": "to like; to take a liking to"
+    },
+    {
+      "ID": "N3#47",
+      "Kana": "きにゅう",
+      "Kanji": "記入",
+      "Definition": "entry; filling in; filling out"
+    },
+    {
+      "ID": "N3#48",
+      "Kana": "きおく",
+      "Kanji": "記憶",
+      "Definition": "memory; recollection; remembrance"
+    },
+    {
+      "ID": "N3#49",
+      "Kana": "きしゃ",
+      "Kanji": "記者",
+      "Definition": "reporter; journalist"
+    },
+    {
+      "ID": "N3#50",
+      "Kana": "きたい",
+      "Kanji": "期待",
+      "Definition": "expectation; anticipation; hope"
+    },
+    {
+      "ID": "N3#51",
+      "Kana": "きょうかしょ",
+      "Kanji": "教科書",
+      "Definition": "textbook; coursebook; schoolbook"
+    },
+    {
+      "ID": "N3#52",
+      "Kana": "きょうりょく",
+      "Kanji": "協力",
+      "Definition": "cooperation; collaboration"
+    },
+    {
+      "ID": "N3#53",
+      "Kana": "きょうりょく",
+      "Kanji": "強力",
+      "Definition": "powerful; strong"
+    },
+    {
+      "ID": "N3#54",
+      "Kana": "きゅうげき",
+      "Kanji": "急激",
+      "Definition": "sudden; abrupt; rapid; sharp; drastic; radical"
+    },
+    {
+      "ID": "N3#55",
+      "Kana": "きゅうに",
+      "Kanji": "急に",
+      "Definition": "swiftly; rapidly; quickly; immediately; hastily"
+    },
+    {
+      "ID": "N3#56",
+      "Kana": "きゅうしゅう",
+      "Kanji": "吸収",
+      "Definition": "absorption; suction; attraction"
+    },
+    {
+      "ID": "N3#57",
+      "Kana": "きゅうそく",
+      "Kanji": "急速",
+      "Definition": "rapid (e.g. progress)"
+    }
+  ],
+  "ぎ": [
+    {
+      "ID": "N3#58",
+      "Kana": "ぎちょう",
+      "Kanji": "議長",
+      "Definition": "chairman; president; moderator"
+    },
+    {
+      "ID": "N3#59",
+      "Kana": "ぎかい",
+      "Kanji": "議会",
+      "Definition": "congress; parliament; diet; legislative assembly"
+    }
+  ],
+  "く": [
+    {
+      "ID": "N3#60",
+      "Kana": "くんれん",
+      "Kanji": "訓練",
+      "Definition": "training; drill; practice; discipline"
+    }
+  ],
+  "け": [
+    {
+      "ID": "N3#61",
+      "Kana": "けんり",
+      "Kanji": "権利",
+      "Definition": "right; privilege"
+    }
+  ],
+  "こ": [
+    {
+      "ID": "N3#62",
+      "Kana": "こっか",
+      "Kanji": "国家",
+      "Definition": "state; country; nation"
+    },
+    {
+      "ID": "N3#63",
+      "Kana": "こっかい",
+      "Kanji": "国会",
+      "Definition": "National Diet; legislative assembly of Japan; parliament; congress"
+    },
+    {
+      "ID": "N3#64",
+      "Kana": "こっきょう",
+      "Kanji": "国境",
+      "Definition": "national border"
+    },
+    {
+      "ID": "N3#65",
+      "Kana": "こくご",
+      "Kanji": "国語",
+      "Definition": "national language"
+    },
+    {
+      "ID": "N3#66",
+      "Kana": "こくみん",
+      "Kanji": "国民",
+      "Definition": "people (of a country); nation; citizen; national"
+    },
+    {
+      "ID": "N3#67",
+      "Kana": "こんご",
+      "Kanji": "今後",
+      "Definition": "from now on; hereafter"
+    },
+    {
+      "ID": "N3#68",
+      "Kana": "こんかい",
+      "Kanji": "今回",
+      "Definition": "now; this time; lately"
+    },
+    {
+      "ID": "N3#69",
+      "Kana": "こんにち",
+      "Kanji": "今日",
+      "Definition": "today; this day"
+    },
+    {
+      "ID": "N3#70",
+      "Kana": "ころぶ",
+      "Kanji": "転ぶ",
+      "Definition": "to fall down; to fall over"
+    },
+    {
+      "ID": "N3#71",
+      "Kana": "こうそく",
+      "Kanji": "高速",
+      "Definition": "high-speed; rapid; express"
+    }
+  ],
+  "ご": [
+    {
+      "ID": "N3#72",
+      "Kana": "ごがく",
+      "Kanji": "語学",
+      "Definition": "study of foreign languages; linguistics"
+    }
+  ],
+  "さ": [
+    {
+      "ID": "N3#73",
+      "Kana": "さくひん",
+      "Kanji": "作品",
+      "Definition": "work of art; performance"
+    },
+    {
+      "ID": "N3#74",
+      "Kana": "さゆう",
+      "Kanji": "左右",
+      "Definition": "left and right"
+    }
+  ],
+  "し": [
+    {
+      "ID": "N3#75",
+      "Kana": "しげき",
+      "Kanji": "刺激",
+      "Definition": "stimulus; impetus; incentive; encouragement; motivation; provocation; excitement; thrill"
+    },
+    {
+      "ID": "N3#76",
+      "Kana": "しほん",
+      "Kanji": "資本",
+      "Definition": "funds; capital"
+    },
+    {
+      "ID": "N3#77",
+      "Kana": "しな",
+      "Kanji": "品",
+      "Definition": "article; item; thing; goods; stock; quality"
+    },
+    {
+      "ID": "N3#78",
+      "Kana": "しんちょう",
+      "Kanji": "身長",
+      "Definition": "body height; stature"
+    },
+    {
+      "ID": "N3#79",
+      "Kana": "しんがく",
+      "Kanji": "進学",
+      "Definition": "entering a higher-level school (often university)"
+    },
+    {
+      "ID": "N3#80",
+      "Kana": "しんせん",
+      "Kanji": "新鮮",
+      "Definition": "fresh"
+    },
+    {
+      "ID": "N3#81",
+      "Kana": "してん",
+      "Kanji": "支店",
+      "Definition": "branch office; branch store​"
+    },
+    {
+      "ID": "N3#82",
+      "Kana": "しよう",
+      "Kanji": "使用",
+      "Definition": "use; application; employment; utilization."
+    },
+    {
+      "ID": "N3#83",
+      "Kana": "しょくひん",
+      "Kanji": "食品",
+      "Definition": "food; food products"
+    },
+    {
+      "ID": "N3#84",
+      "Kana": "しょもつ",
+      "Kanji": "書物",
+      "Definition": "book; volume"
+    },
+    {
+      "ID": "N3#85",
+      "Kana": "しょるい",
+      "Kanji": "書類",
+      "Definition": "document; official papers"
+    },
+    {
+      "ID": "N3#86",
+      "Kana": "しょさい",
+      "Kanji": "書斎",
+      "Definition": "study; library; den; home office; reading room"
+    },
+    {
+      "ID": "N3#87",
+      "Kana": "しょうばい",
+      "Kanji": "商売",
+      "Definition": "trade; business; commerce; transaction; occupation"
+    },
+    {
+      "ID": "N3#88",
+      "Kana": "しょうがくきん",
+      "Kanji": "奨学金",
+      "Definition": "scholarship; stipend; student loan"
+    },
+    {
+      "ID": "N3#89",
+      "Kana": "しょうご",
+      "Kanji": "正午",
+      "Definition": "midday"
+    },
+    {
+      "ID": "N3#90",
+      "Kana": "しょうひん",
+      "Kanji": "商品",
+      "Definition": "commodity; article of commerce; goods; stock; merchandise"
+    },
+    {
+      "ID": "N3#91",
+      "Kana": "しょうじょ",
+      "Kanji": "少女",
+      "Definition": "little girl; maiden; young lady"
+    },
+    {
+      "ID": "N3#92",
+      "Kana": "しょうめい",
+      "Kanji": "証明",
+      "Definition": "proof; verification; certification"
+    },
+    {
+      "ID": "N3#93",
+      "Kana": "しょうねん",
+      "Kanji": "少年",
+      "Definition": "boy; juvenile; young boy; youth; lad"
+    },
+    {
+      "ID": "N3#94",
+      "Kana": "しょうしょう",
+      "Kanji": "少々",
+      "Definition": "just a minute; small quantity"
+    },
+    {
+      "ID": "N3#95",
+      "Kana": "しゅうちゅう",
+      "Kanji": "集中",
+      "Definition": "concentration; focusing; centralization; integration"
+    },
+    {
+      "ID": "N3#96",
+      "Kana": "しゅうだん",
+      "Kanji": "集団",
+      "Definition": "group; mass"
+    },
+    {
+      "ID": "N3#97",
+      "Kana": "しゅうかく",
+      "Kanji": "収穫",
+      "Definition": "harvest; crop; fruits (of one's labors)"
+    },
+    {
+      "ID": "N3#98",
+      "Kana": "しゅうかん",
+      "Kanji": "週間",
+      "Definition": "week"
+    },
+    {
+      "ID": "N3#99",
+      "Kana": "しゅうかん",
+      "Kanji": "週刊",
+      "Definition": "weekly publication"
+    },
+    {
+      "ID": "N3#100",
+      "Kana": "しゅうにゅう",
+      "Kanji": "収入",
+      "Definition": "income; receipts; revenue; salary"
+    }
+  ],
+  "す": [
+    {
+      "ID": "N3#101",
+      "Kana": "すこしも",
+      "Kanji": "少しも",
+      "Definition": "anything of; not one bit (with negative sentence)"
+    }
+  ],
+  "せ": [
+    {
+      "ID": "N3#102",
+      "Kana": "せいちょう",
+      "Kanji": "成長",
+      "Definition": "growth; development; growing up; becoming an adult"
+    },
+    {
+      "ID": "N3#103",
+      "Kana": "せいひん",
+      "Kanji": "製品",
+      "Definition": "manufactured goods; finished goods; product"
+    },
+    {
+      "ID": "N3#104",
+      "Kana": "せいねん",
+      "Kanji": "青年",
+      "Definition": "youth; young man"
+    }
+  ],
+  "ぜ": [
+    {
+      "ID": "N3#105",
+      "Kana": "ぜんこく",
+      "Kanji": "全国",
+      "Definition": "the whole country"
+    }
+  ],
+  "そ": [
+    {
+      "ID": "N3#106",
+      "Kana": "そくど",
+      "Kanji": "速度",
+      "Definition": "speed; velocity; pace; rate"
+    }
+  ],
+  "た": [
+    {
+      "ID": "N3#107",
+      "Kana": "たいはん",
+      "Kanji": "大半",
+      "Definition": "majority; more than half; most; largely; mainly"
+    },
+    {
+      "ID": "N3#108",
+      "Kana": "たいかい",
+      "Kanji": "大会",
+      "Definition": "convention; rally; conference; tournament;"
+    },
+    {
+      "ID": "N3#109",
+      "Kana": "たいした",
+      "Kanji": "大した",
+      "Definition": "considerable; great; important; significant; a big deal"
+    },
+    {
+      "ID": "N3#110",
+      "Kana": "たんなる",
+      "Kanji": "単なる",
+      "Definition": "mere; simple; sheer"
+    },
+    {
+      "ID": "N3#111",
+      "Kana": "たしょう",
+      "Kanji": "多少",
+      "Definition": "more or less; somewhat; a little; a few; some"
+    }
+  ],
+  "だ": [
+    {
+      "ID": "N3#112",
+      "Kana": "だいぶぶん",
+      "Kanji": "大部分",
+      "Definition": "most part; greater part; majority"
+    },
+    {
+      "ID": "N3#113",
+      "Kana": "だんし",
+      "Kanji": "男子",
+      "Definition": "youth; young man"
+    }
+  ],
+  "ち": [
+    {
+      "ID": "N3#114",
+      "Kana": "ちちおや",
+      "Kanji": "父親",
+      "Definition": "father"
+    },
+    {
+      "ID": "N3#115",
+      "Kana": "ちへいせん",
+      "Kanji": "地平線",
+      "Definition": "horizon (related to land)​"
+    },
+    {
+      "ID": "N3#116",
+      "Kana": "ちい",
+      "Kanji": "地位",
+      "Definition": "(social) position; status"
+    },
+    {
+      "ID": "N3#117",
+      "Kana": "ちょうき",
+      "Kanji": "長期",
+      "Definition": "long-term"
+    },
+    {
+      "ID": "N3#118",
+      "Kana": "ちゅうがく",
+      "Kanji": "中学",
+      "Definition": "junior high school; middle school"
+    },
+    {
+      "ID": "N3#119",
+      "Kana": "ちゅうしょく",
+      "Kanji": "昼食",
+      "Definition": "lunch; midday meal"
+    }
+  ],
+  "つ": [
+    {
+      "ID": "N3#120",
+      "Kana": "つうがく",
+      "Kanji": "通学",
+      "Definition": "commuting to school; school commute"
+    }
+  ],
+  "て": [
+    {
+      "ID": "N3#121",
+      "Kana": "てじな",
+      "Kanji": "手品",
+      "Definition": "magic trick; illusion"
+    },
+    {
+      "ID": "N3#122",
+      "Kana": "てつがく",
+      "Kanji": "哲学",
+      "Definition": "philosophy"
+    },
+    {
+      "ID": "N3#123",
+      "Kana": "てつや",
+      "Kanji": "徹夜",
+      "Definition": "staying up all night"
+    }
+  ],
+  "で": [
+    {
+      "ID": "N3#124",
+      "Kana": "であい",
+      "Kanji": "出会い",
+      "Definition": "meeting; rendezvous; encounter"
+    },
+    {
+      "ID": "N3#125",
+      "Kana": "であう",
+      "Kanji": "出会う",
+      "Definition": "to meet (by chance); to come across; to run across; to encounter"
+    }
+  ],
+  "と": [
+    {
+      "ID": "N3#126",
+      "Kana": "とち",
+      "Kanji": "土地",
+      "Definition": "plot of land; lot; soil"
+    },
+    {
+      "ID": "N3#127",
+      "Kana": "とかい",
+      "Kanji": "都会",
+      "Definition": "(big) city"
+    },
+    {
+      "ID": "N3#128",
+      "Kana": "とれる",
+      "Kanji": "取れる",
+      "Definition": "to come off; to be removed; to be obtainable"
+    },
+    {
+      "ID": "N3#129",
+      "Kana": "とりあげる",
+      "Kanji": "取り上げる",
+      "Definition": "to pick up"
+    },
+    {
+      "ID": "N3#130",
+      "Kana": "としょ",
+      "Kanji": "図書",
+      "Definition": "books"
+    }
+  ],
+  "ど": [
+    {
+      "ID": "N3#131",
+      "Kana": "どくしょ",
+      "Kanji": "読書",
+      "Definition": "reading"
+    },
+    {
+      "ID": "N3#132",
+      "Kana": "どりょく",
+      "Kanji": "努力",
+      "Definition": "effort; exertion; endeavor; hard work; striving"
+    },
+    {
+      "ID": "N3#133",
+      "Kana": "どういつ",
+      "Kanji": "同一",
+      "Definition": "identical; same; one and the same; equal"
+    }
+  ],
+  "な": [
+    {
+      "ID": "N3#134",
+      "Kana": "なかば",
+      "Kanji": "半ば",
+      "Definition": "middle; half; semi; halfway; partly"
+    }
+  ],
+  "に": [
+    {
+      "ID": "N3#135",
+      "Kana": "にほん",
+      "Kanji": "日本",
+      "Definition": "Japan"
+    },
+    {
+      "ID": "N3#136",
+      "Kana": "にゅうじょう",
+      "Kanji": "入場",
+      "Definition": "entrance; admission; entering"
+    }
+  ],
+  "の": [
+    {
+      "ID": "N3#137",
+      "Kana": "のうりょく",
+      "Kanji": "能力",
+      "Definition": "ability; faculty"
+    }
+  ],
+  "は": [
+    {
+      "ID": "N3#138",
+      "Kana": "はげしい",
+      "Kanji": "激しい",
+      "Definition": "violent; extreme; intense"
+    },
+    {
+      "ID": "N3#139",
+      "Kana": "ははおや",
+      "Kanji": "母親",
+      "Definition": "mother"
+    },
+    {
+      "ID": "N3#140",
+      "Kana": "はくぶつかん",
+      "Kanji": "博物館",
+      "Definition": "museum"
+    },
+    {
+      "ID": "N3#141",
+      "Kana": "はんばい",
+      "Kanji": "販売",
+      "Definition": "sales; selling; marketing"
+    },
+    {
+      "ID": "N3#142",
+      "Kana": "はつめい",
+      "Kanji": "発明",
+      "Definition": "invention"
+    },
+    {
+      "ID": "N3#143",
+      "Kana": "はずす",
+      "Kanji": "外す",
+      "Definition": "to remove; to undo; to drop; to miss"
+    }
+  ],
+  "ひ": [
+    {
+      "ID": "N3#144",
+      "Kana": "ひとこと",
+      "Kanji": "一言",
+      "Definition": "single word; a few words; brief comment"
+    },
+    {
+      "ID": "N3#145",
+      "Kana": "ひとりひとり",
+      "Kanji": "一人一人",
+      "Definition": "one by one; each; one at a time"
+    }
+  ],
+  "ふ": [
+    {
+      "ID": "N3#146",
+      "Kana": "ふり",
+      "Kanji": "不利",
+      "Definition": "disadvantage; handicap; unfavorable position"
+    },
+    {
+      "ID": "N3#147",
+      "Kana": "ふそく",
+      "Kanji": "不足",
+      "Definition": "insufficiency; shortage; deficiency; lack; dearth"
+    },
+    {
+      "ID": "N3#148",
+      "Kana": "ふたたび",
+      "Kanji": "再び",
+      "Definition": "again; once more; a second time"
+    }
+  ],
+  "ぶ": [
+    {
+      "ID": "N3#149",
+      "Kana": "ぶぶん",
+      "Kanji": "部分",
+      "Definition": "portion; section; part"
+    },
+    {
+      "ID": "N3#150",
+      "Kana": "ぶんめい",
+      "Kanji": "文明",
+      "Definition": "civilization; culture"
+    },
+    {
+      "ID": "N3#151",
+      "Kana": "ぶんせき",
+      "Kanji": "分析",
+      "Definition": "analysis"
+    },
+    {
+      "ID": "N3#152",
+      "Kana": "ぶんや",
+      "Kanji": "分野",
+      "Definition": "field; sphere; realm; division; branch"
+    }
+  ],
+  "ほ": [
+    {
+      "ID": "N3#153",
+      "Kana": "ほんもの",
+      "Kanji": "本物",
+      "Definition": "genuine article; real thing; real deal​"
+    },
+    {
+      "ID": "N3#154",
+      "Kana": "ほんにん",
+      "Kanji": "本人",
+      "Definition": "the person in question; the person themselves; said person"
+    }
+  ],
+  "ま": [
+    {
+      "ID": "N3#155",
+      "Kana": "まっか",
+      "Kanji": "真っ赤",
+      "Definition": "bright red; deep red; flushed (of face)"
+    },
+    {
+      "ID": "N3#156",
+      "Kana": "まなぶ",
+      "Kanji": "学ぶ",
+      "Definition": "to study (in depth); to learn; to take lessons in"
+    },
+    {
+      "ID": "N3#157",
+      "Kana": "まんいち",
+      "Kanji": "万一",
+      "Definition": "emergency; unlikely event​; by some chance; by some possibility"
+    },
+    {
+      "ID": "N3#158",
+      "Kana": "まんぞく",
+      "Kanji": "満足",
+      "Definition": "satisfaction; contentment;​ sufficient; enough"
+    }
+  ],
+  "み": [
+    {
+      "ID": "N3#159",
+      "Kana": "みかた",
+      "Kanji": "味方",
+      "Definition": "friend; ally; supporter; taking sides with; supporting"
+    },
+    {
+      "ID": "N3#160",
+      "Kana": "みりょく",
+      "Kanji": "魅力",
+      "Definition": "charm; fascination; glamour; attraction; appeal"
+    }
+  ],
+  "め": [
+    {
+      "ID": "N3#161",
+      "Kana": "めいかく",
+      "Kanji": "明確",
+      "Definition": "clear; precise; definite; distinct"
+    },
+    {
+      "ID": "N3#162",
+      "Kana": "めし",
+      "Kanji": "飯",
+      "Definition": "cooked rice; meal"
+    }
+  ],
+  "も": [
+    {
+      "ID": "N3#163",
+      "Kana": "もくよう",
+      "Kanji": "木曜",
+      "Definition": "Thursday"
+    }
+  ],
+  "ゆ": [
+    {
+      "ID": "N3#164",
+      "Kana": "ゆいいつ",
+      "Kanji": "唯一",
+      "Definition": "only; sole; unique"
+    },
+    {
+      "ID": "N3#165",
+      "Kana": "ゆうべ",
+      "Kanji": "夕べ",
+      "Definition": "evening / last night; yesterday evening"
+    },
+    {
+      "ID": "N3#166",
+      "Kana": "ゆうり",
+      "Kanji": "有利",
+      "Definition": "advantageous; favorable; profitable"
+    }
+  ],
+  "よ": [
+    {
+      "ID": "N3#167",
+      "Kana": "よあけ",
+      "Kanji": "夜明け",
+      "Definition": "dawn; daybreak"
+    },
+    {
+      "ID": "N3#168",
+      "Kana": "よぶん",
+      "Kanji": "余分",
+      "Definition": "extra; excess; surplus"
+    },
+    {
+      "ID": "N3#169",
+      "Kana": "よみ",
+      "Kanji": "読み",
+      "Definition": "reading (of a kanji, situation, etc)"
+    },
+    {
+      "ID": "N3#170",
+      "Kana": "よなか",
+      "Kanji": "夜中",
+      "Definition": "middle of the night; dead of night"
+    }
+  ],
+  "り": [
+    {
+      "ID": "N3#171",
+      "Kana": "りえき",
+      "Kanji": "利益",
+      "Definition": "profit; gains; benefit"
+    },
+    {
+      "ID": "N3#172",
+      "Kana": "りこう",
+      "Kanji": "利口",
+      "Definition": "clever; intelligent; wise; bright; sharp"
+    },
+    {
+      "ID": "N3#173",
+      "Kana": "りゅうがく",
+      "Kanji": "留学",
+      "Definition": "studying abroad"
+    }
+  ],
+  "れ": [
+    {
+      "ID": "N3#174",
+      "Kana": "れんぞく",
+      "Kanji": "連続",
+      "Definition": "continuation; succession; series"
+    }
+  ],
+  "わ": [
+    {
+      "ID": "N3#175",
+      "Kana": "わける",
+      "Kanji": "分ける",
+      "Definition": "to divide; to split; to part; to separate"
+    },
+    {
+      "ID": "N3#176",
+      "Kana": "わるぐち",
+      "Kanji": "悪口",
+      "Definition": "slander; bad-mouthing; abuse; insult; speaking ill (of)"
+    }
+  ]
+}

--- a/vocab-n4.json
+++ b/vocab-n4.json
@@ -1,141 +1,169 @@
 {
   "あ": [
     {
+      "ID": "N4#1",
       "Kana": "あ",
       "Kanji": "",
       "Definition": "Ah"
     },
     {
+      "ID": "N4#2",
       "Kana": "あいさつ",
       "Kanji": "",
       "Definition": "greeting"
     },
     {
+      "ID": "N4#3",
       "Kana": "あいさつする",
       "Kanji": "",
       "Definition": "to greet"
     },
     {
+      "ID": "N4#4",
       "Kana": "あいだ",
       "Kanji": "間",
       "Definition": "space, interval"
     },
     {
+      "ID": "N4#5",
       "Kana": "あう",
       "Kanji": "合う",
       "Definition": "to fit, to match"
     },
     {
+      "ID": "N4#6",
       "Kana": "あかちゃん",
       "Kanji": "",
       "Definition": "baby, infant"
     },
     {
+      "ID": "N4#7",
       "Kana": "あがる",
       "Kanji": "上がる",
       "Definition": "to rise, to go up"
     },
     {
+      "ID": "N4#8",
       "Kana": "あかんぼう",
       "Kanji": "赤ん坊",
       "Definition": "baby"
     },
     {
+      "ID": "N4#9",
       "Kana": "あく",
       "Kanji": "空く",
       "Definition": "to open, to become empty"
     },
     {
+      "ID": "N4#10",
       "Kana": "アクセサリー",
       "Kanji": "",
       "Definition": "accessory"
     },
     {
+      "ID": "N4#11",
       "Kana": "あさい",
       "Kanji": "浅い",
       "Definition": "shallow, superficial"
     },
     {
+      "ID": "N4#12",
       "Kana": "あじ",
       "Kanji": "味",
       "Definition": "flavor, taste"
     },
     {
+      "ID": "N4#13",
       "Kana": "アジア",
       "Kanji": "",
       "Definition": "Asia"
     },
     {
+      "ID": "N4#14",
       "Kana": "あす",
       "Kanji": "明日",
       "Definition": "tomorrow"
     },
     {
+      "ID": "N4#15",
       "Kana": "あそび",
       "Kanji": "遊び",
       "Definition": "play"
     },
     {
+      "ID": "N4#16",
       "Kana": "あつまる",
       "Kanji": "集る",
       "Definition": "to gather, to collect"
     },
     {
+      "ID": "N4#17",
       "Kana": "あつめる",
       "Kanji": "集める",
       "Definition": "to collect, to assemble"
     },
     {
+      "ID": "N4#18",
       "Kana": "アナウンサー",
       "Kanji": "",
       "Definition": "announcer"
     },
     {
+      "ID": "N4#19",
       "Kana": "アフリカ",
       "Kanji": "",
       "Definition": "Africa"
     },
     {
+      "ID": "N4#20",
       "Kana": "アメリカ",
       "Kanji": "",
       "Definition": "America"
     },
     {
+      "ID": "N4#21",
       "Kana": "あやまる",
       "Kanji": "謝る",
       "Definition": "to apologize"
     },
     {
+      "ID": "N4#22",
       "Kana": "アルコール",
       "Kanji": "",
       "Definition": "alcohol"
     },
     {
+      "ID": "N4#23",
       "Kana": "アルバイト",
       "Kanji": "",
       "Definition": "part-time job"
     },
     {
+      "ID": "N4#24",
       "Kana": "あんしん",
       "Kanji": "安心",
       "Definition": "peace of mind, relief"
     },
     {
+      "ID": "N4#25",
       "Kana": "あんぜん",
       "Kanji": "安全",
       "Definition": "safety, security"
     },
     {
+      "ID": "N4#26",
       "Kana": "あんな",
       "Kanji": "",
       "Definition": "such, like that"
     },
     {
+      "ID": "N4#27",
       "Kana": "あんない",
       "Kanji": "案内",
       "Definition": "information, guidance"
     },
     {
+      "ID": "N4#28",
       "Kana": "あんないする",
       "Kanji": "案内する",
       "Definition": "to inform, to guide"
@@ -143,96 +171,115 @@
   ],
   "い": [
     {
+      "ID": "N4#29",
       "Kana": "いか",
       "Kanji": "以下",
       "Definition": "less than, below"
     },
     {
+      "ID": "N4#30",
       "Kana": "いがい",
       "Kanji": "以外",
       "Definition": "with the exception of, excepting"
     },
     {
+      "ID": "N4#31",
       "Kana": "いがく",
       "Kanji": "医学",
       "Definition": "medical science"
     },
     {
+      "ID": "N4#32",
       "Kana": "いきる",
       "Kanji": "生きる",
       "Definition": "to live, to exist"
     },
     {
+      "ID": "N4#33",
       "Kana": "いけん",
       "Kanji": "意見",
       "Definition": "opinion, view"
     },
     {
+      "ID": "N4#34",
       "Kana": "いし",
       "Kanji": "石",
       "Definition": "stone"
     },
     {
+      "ID": "N4#35",
       "Kana": "いじめる",
       "Kanji": "",
       "Definition": "to tease, to torment"
     },
     {
+      "ID": "N4#36",
       "Kana": "いじょう",
       "Kanji": "以上",
       "Definition": "more than, this is all"
     },
     {
+      "ID": "N4#37",
       "Kana": "いそぐ",
       "Kanji": "急ぐ",
       "Definition": "to hurry, to rush"
     },
     {
+      "ID": "N4#38",
       "Kana": "いたす",
       "Kanji": "致す",
       "Definition": "(hum) to do"
     },
     {
+      "ID": "N4#39",
       "Kana": "いただく",
       "Kanji": "",
       "Definition": "to receive, to take food or drink (hum)"
     },
     {
+      "ID": "N4#40",
       "Kana": "いちど",
       "Kanji": "一度",
       "Definition": "once, one time"
     },
     {
+      "ID": "N4#41",
       "Kana": "いっしょうけんめい",
       "Kanji": "一生懸命",
       "Definition": "as well as one can, with utmost effort"
     },
     {
+      "ID": "N4#42",
       "Kana": "いっぱい",
       "Kanji": "",
       "Definition": "full, to the utmost"
     },
     {
+      "ID": "N4#43",
       "Kana": "いと",
       "Kanji": "糸",
       "Definition": "thread"
     },
     {
+      "ID": "N4#44",
       "Kana": "いない",
       "Kanji": "以内",
       "Definition": "within, inside of"
     },
     {
+      "ID": "N4#45",
       "Kana": "いなか",
       "Kanji": "田舎",
       "Definition": "rural, countryside"
     },
     {
+      "ID": "N4#46",
       "Kana": "いのる",
       "Kanji": "祈る",
       "Definition": "to pray, to wish"
     },
     {
+      "ID": "N4#47",
       "Kana": "いらっしゃる",
       "Kanji": "",
       "Definition": "(hon) to be, to come, to go"
@@ -240,116 +287,139 @@
   ],
   "う": [
     {
+      "ID": "N4#48",
       "Kana": "うえる",
       "Kanji": "植える",
       "Definition": "to plant, to grow"
     },
     {
+      "ID": "N4#49",
       "Kana": "うかがう",
       "Kanji": "",
       "Definition": "to visit"
     },
     {
+      "ID": "N4#50",
       "Kana": "うかがう",
       "Kanji": "",
       "Definition": "to ask"
     },
     {
+      "ID": "N4#51",
       "Kana": "うけつけ",
       "Kanji": "受付",
       "Definition": "reception (desk), information ガス"
     },
     {
+      "ID": "N4#52",
       "Kana": "うける",
       "Kanji": "受ける",
       "Definition": "to take (lesson, test), to undergo"
     },
     {
+      "ID": "N4#53",
       "Kana": "うごく",
       "Kanji": "動く",
       "Definition": "to move"
     },
     {
+      "ID": "N4#54",
       "Kana": "うそ",
       "Kanji": "",
       "Definition": "lie"
     },
     {
+      "ID": "N4#55",
       "Kana": "うち",
       "Kanji": "",
       "Definition": "within"
     },
     {
+      "ID": "N4#56",
       "Kana": "うつ",
       "Kanji": "打つ",
       "Definition": "to hit, to strike"
     },
     {
+      "ID": "N4#57",
       "Kana": "うつくしい",
       "Kanji": "美しい",
       "Definition": "beautiful, lovely"
     },
     {
+      "ID": "N4#58",
       "Kana": "うつす",
       "Kanji": "写す",
       "Definition": "copy, to photograph, to film"
     },
     {
+      "ID": "N4#59",
       "Kana": "うつる",
       "Kanji": "移る",
       "Definition": "to move (house), to transfer (department)"
     },
     {
+      "ID": "N4#60",
       "Kana": "うで",
       "Kanji": "腕",
       "Definition": "arm"
     },
     {
+      "ID": "N4#61",
       "Kana": "うまい",
       "Kanji": "",
       "Definition": "delicious"
     },
     {
+      "ID": "N4#62",
       "Kana": "うら",
       "Kanji": "裏",
       "Definition": "reverse side, wrong side, back"
     },
     {
+      "ID": "N4#63",
       "Kana": "うりば",
       "Kanji": "売り場",
       "Definition": "place where things are sold"
     },
     {
+      "ID": "N4#64",
       "Kana": "うれしい",
       "Kanji": "",
       "Definition": "happy, glad"
     },
     {
+      "ID": "N4#65",
       "Kana": "うん",
       "Kanji": "",
       "Definition": "yes (informal), alright"
     },
     {
+      "ID": "N4#66",
       "Kana": "うんてんしゅ",
       "Kanji": "運転手",
       "Definition": "driver, chauffeur"
     },
     {
+      "ID": "N4#67",
       "Kana": "うんてん",
       "Kanji": "運転",
       "Definition": "driving"
     },
     {
+      "ID": "N4#68",
       "Kana": "うんてんする",
       "Kanji": "運転する",
       "Definition": "to drive"
     },
     {
+      "ID": "N4#69",
       "Kana": "うんどう",
       "Kanji": "運動",
       "Definition": "exercise"
     },
     {
+      "ID": "N4#70",
       "Kana": "うんどうする",
       "Kanji": "運動する",
       "Definition": "to exercise"
@@ -357,26 +427,31 @@
   ],
   "え": [
     {
+      "ID": "N4#71",
       "Kana": "エスカレーター",
       "Kanji": "",
       "Definition": "escalator"
     },
     {
+      "ID": "N4#72",
       "Kana": "えだ",
       "Kanji": "枝",
       "Definition": "branch, twig"
     },
     {
+      "ID": "N4#73",
       "Kana": "えらぶ",
       "Kanji": "選ぶ",
       "Definition": "to choose, to select"
     },
     {
+      "ID": "N4#74",
       "Kana": "えんりょ",
       "Kanji": "遠慮",
       "Definition": "restraint, reserve"
     },
     {
+      "ID": "N4#75",
       "Kana": "えんりょする",
       "Kanji": "遠慮する",
       "Definition": "to restrain, to reserve"
@@ -384,206 +459,247 @@
   ],
   "お": [
     {
+      "ID": "N4#76",
       "Kana": "おいでになる",
       "Kanji": "",
       "Definition": "(hon)to be"
     },
     {
+      "ID": "N4#77",
       "Kana": "おいわい",
       "Kanji": "お祝い",
       "Definition": "congratulation, celebration"
     },
     {
+      "ID": "N4#78",
       "Kana": "オートバイ",
       "Kanji": "",
       "Definition": "motorcycle (lit: auto-bi(ke))"
     },
     {
+      "ID": "N4#79",
       "Kana": "オーバー",
       "Kanji": "",
       "Definition": "overcoat"
     },
     {
+      "ID": "N4#80",
       "Kana": "おかげ",
       "Kanji": "",
       "Definition": "thanks or owing to"
     },
     {
+      "ID": "N4#81",
       "Kana": "おかしい",
       "Kanji": "",
       "Definition": "strange, funny"
     },
     {
+      "ID": "N4#82",
       "Kana": "おく",
       "Kanji": "億",
       "Definition": "100,000,000, hundred million"
     },
     {
+      "ID": "N4#83",
       "Kana": "おくじょう",
       "Kanji": "屋上",
       "Definition": "rooftop"
     },
     {
+      "ID": "N4#84",
       "Kana": "おくりもの",
       "Kanji": "贈り物",
       "Definition": "present, gift"
     },
     {
+      "ID": "N4#85",
       "Kana": "おくる",
       "Kanji": "送る",
       "Definition": "to send (a thing), to dispatch"
     },
     {
+      "ID": "N4#86",
       "Kana": "おくれる",
       "Kanji": "遅れる",
       "Definition": "to be late, to be delayed"
     },
     {
+      "ID": "N4#87",
       "Kana": "おこさん",
       "Kanji": "お子さん",
       "Definition": "(someone else's) child"
     },
     {
+      "ID": "N4#88",
       "Kana": "おこす",
       "Kanji": "起こす",
       "Definition": "to wake someone"
     },
     {
+      "ID": "N4#89",
       "Kana": "おこなう",
       "Kanji": "行う",
       "Definition": "to perform, to do, to carry out"
     },
     {
+      "ID": "N4#90",
       "Kana": "おこる",
       "Kanji": "怒る",
       "Definition": "to get angry, to be angry"
     },
     {
+      "ID": "N4#91",
       "Kana": "おしいれ",
       "Kanji": "押し入れ",
       "Definition": "closet"
     },
     {
+      "ID": "N4#92",
       "Kana": "おじょうさん",
       "Kanji": "お嬢さん",
       "Definition": "(1) (hon) daughter, (2) young lady"
     },
     {
+      "ID": "N4#93",
       "Kana": "おたく",
       "Kanji": "お宅",
       "Definition": "(pol) your house, your home"
     },
     {
+      "ID": "N4#94",
       "Kana": "おちる",
       "Kanji": "落ちる",
       "Definition": "to fall, to drop"
     },
     {
+      "ID": "N4#95",
       "Kana": "おっしゃる",
       "Kanji": "",
       "Definition": "(hon) to say, to speak"
     },
     {
+      "ID": "N4#96",
       "Kana": "おっと",
       "Kanji": "夫",
       "Definition": "husband"
     },
     {
+      "ID": "N4#97",
       "Kana": "おつり",
       "Kanji": "",
       "Definition": "change (money), balance"
     },
     {
+      "ID": "N4#98",
       "Kana": "おと",
       "Kanji": "音",
       "Definition": "sound, note"
     },
     {
+      "ID": "N4#99",
       "Kana": "おとす",
       "Kanji": "落す",
       "Definition": "to drop, to lose"
     },
     {
+      "ID": "N4#100",
       "Kana": "おどり",
       "Kanji": "踊り",
       "Definition": "dance"
     },
     {
+      "ID": "N4#101",
       "Kana": "おどる",
       "Kanji": "踊る",
       "Definition": "to dance"
     },
     {
+      "ID": "N4#102",
       "Kana": "おどろく",
       "Kanji": "驚く",
       "Definition": "to be surprised, to be astonished"
     },
     {
+      "ID": "N4#103",
       "Kana": "おまつり",
       "Kanji": "お祭り",
       "Definition": "festival"
     },
     {
+      "ID": "N4#104",
       "Kana": "おみまい",
       "Kanji": "お見舞い",
       "Definition": "calling on someone who is ill, enquiry"
     },
     {
+      "ID": "N4#105",
       "Kana": "おみやげ",
       "Kanji": "お土産",
       "Definition": "souvenir"
     },
     {
+      "ID": "N4#106",
       "Kana": "おもいだす",
       "Kanji": "思い出す",
       "Definition": "to recall, to remember"
     },
     {
+      "ID": "N4#107",
       "Kana": "おもう",
       "Kanji": "思う",
       "Definition": "to think, to feel"
     },
     {
+      "ID": "N4#108",
       "Kana": "おもちゃ",
       "Kanji": "",
       "Definition": "toy"
     },
     {
+      "ID": "N4#109",
       "Kana": "おもて",
       "Kanji": "表",
       "Definition": "the front, surface, exterior"
     },
     {
+      "ID": "N4#110",
       "Kana": "おや",
       "Kanji": "親",
       "Definition": "parents"
     },
     {
+      "ID": "N4#111",
       "Kana": "おりる",
       "Kanji": "下りる",
       "Definition": "to descend a mountain, to (descend) go down stairs"
     },
     {
+      "ID": "N4#112",
       "Kana": "おる",
       "Kanji": "",
       "Definition": "to be (polite version of いる)"
     },
     {
+      "ID": "N4#113",
       "Kana": "おる",
       "Kanji": "折る",
       "Definition": "to break, to fold, to pick a flower"
     },
     {
+      "ID": "N4#114",
       "Kana": "おれい",
       "Kanji": "お礼",
       "Definition": "thanking, expression of gratitude"
     },
     {
+      "ID": "N4#115",
       "Kana": "おれる",
       "Kanji": "折れる",
       "Definition": "to break, to be folded, to give in, to turn (a corner)"
     },
     {
+      "ID": "N4#116",
       "Kana": "おわり",
       "Kanji": "終わり",
       "Definition": "the end"
@@ -591,206 +707,247 @@
   ],
   "か": [
     {
+      "ID": "N4#117",
       "Kana": "カーテン",
       "Kanji": "",
       "Definition": "curtain"
     },
     {
+      "ID": "N4#118",
       "Kana": "かいがん",
       "Kanji": "海岸",
       "Definition": "coast, beach"
     },
     {
+      "ID": "N4#119",
       "Kana": "かいぎ",
       "Kanji": "会議",
       "Definition": "meeting, conference"
     },
     {
+      "ID": "N4#120",
       "Kana": "かいぎしつ",
       "Kanji": "会議室",
       "Definition": "conference room"
     },
     {
+      "ID": "N4#121",
       "Kana": "かいじょう",
       "Kanji": "会場",
       "Definition": "assembly hall, meeting place, the grounds"
     },
     {
+      "ID": "N4#122",
       "Kana": "かいわ",
       "Kanji": "会話",
       "Definition": "conversation"
     },
     {
+      "ID": "N4#123",
       "Kana": "かえり",
       "Kanji": "帰り",
       "Definition": "return, coming back"
     },
     {
+      "ID": "N4#124",
       "Kana": "かえる",
       "Kanji": "変える",
       "Definition": "to change, to alter, to vary"
     },
     {
+      "ID": "N4#125",
       "Kana": "かがく",
       "Kanji": "科学",
       "Definition": "science"
     },
     {
+      "ID": "N4#126",
       "Kana": "かがみ",
       "Kanji": "鏡",
       "Definition": "mirror"
     },
     {
+      "ID": "N4#127",
       "Kana": "かける",
       "Kanji": "掛ける",
       "Definition": "to hang, to put on (eg wall)"
     },
     {
+      "ID": "N4#128",
       "Kana": "かける",
       "Kanji": "",
       "Definition": "to sit down"
     },
     {
+      "ID": "N4#129",
       "Kana": "かける",
       "Kanji": "",
       "Definition": "to begin to"
     },
     {
+      "ID": "N4#130",
       "Kana": "かざる",
       "Kanji": "飾る",
       "Definition": "to decorate, to ornament, to adorn"
     },
     {
+      "ID": "N4#131",
       "Kana": "かじ",
       "Kanji": "火事",
       "Definition": "fire"
     },
     {
+      "ID": "N4#132",
       "Kana": "かた",
       "Kanji": "方",
       "Definition": "way of doing"
     },
     {
+      "ID": "N4#133",
       "Kana": "かたい",
       "Kanji": "堅/硬/固い",
       "Definition": "solid, hard, firm"
     },
     {
+      "ID": "N4#134",
       "Kana": "かたち",
       "Kanji": "形",
       "Definition": "shape"
     },
     {
+      "ID": "N4#135",
       "Kana": "かたづける",
       "Kanji": "片付ける",
       "Definition": "to tidy up, to put in order, to put away"
     },
     {
+      "ID": "N4#136",
       "Kana": "かちょう",
       "Kanji": "課長",
       "Definition": "section manager"
     },
     {
+      "ID": "N4#137",
       "Kana": "かつ",
       "Kanji": "勝つ",
       "Definition": "to win, to gain victory"
     },
     {
+      "ID": "N4#138",
       "Kana": "かっこう",
       "Kanji": "",
       "Definition": "appearance, manner"
     },
     {
+      "ID": "N4#139",
       "Kana": "かない",
       "Kanji": "家内",
       "Definition": "housewife"
     },
     {
+      "ID": "N4#140",
       "Kana": "かなしい",
       "Kanji": "悲しい",
       "Definition": "sad, sorrowful"
     },
     {
+      "ID": "N4#141",
       "Kana": "かならず",
       "Kanji": "必ず",
       "Definition": "certainly, necessarily, invariably"
     },
     {
+      "ID": "N4#142",
       "Kana": "かねもち/おかねもち",
       "Kanji": "お・金持ち",
       "Definition": "rich man"
     },
     {
+      "ID": "N4#143",
       "Kana": "かのじょ",
       "Kanji": "彼女",
       "Definition": "she, girl-friend"
     },
     {
+      "ID": "N4#144",
       "Kana": "かべ",
       "Kanji": "壁",
       "Definition": "wall"
     },
     {
+      "ID": "N4#145",
       "Kana": "かまう",
       "Kanji": "",
       "Definition": "to mind, to care about"
     },
     {
+      "ID": "N4#146",
       "Kana": "かみ",
       "Kanji": "髪",
       "Definition": "hair"
     },
     {
+      "ID": "N4#147",
       "Kana": "かむ",
       "Kanji": "噛む",
       "Definition": "to bite, to chew"
     },
     {
+      "ID": "N4#148",
       "Kana": "かよう",
       "Kanji": "通う",
       "Definition": "(1) to go back and forth, (2) to commute"
     },
     {
+      "ID": "N4#149",
       "Kana": "かれ",
       "Kanji": "彼",
       "Definition": "he, boyfriend"
     },
     {
+      "ID": "N4#150",
       "Kana": "かれら",
       "Kanji": "彼ら",
       "Definition": "they (usually male)"
     },
     {
+      "ID": "N4#151",
       "Kana": "かわく",
       "Kanji": "乾く",
       "Definition": "to get dry"
     },
     {
+      "ID": "N4#152",
       "Kana": "かわり",
       "Kanji": "代わり",
       "Definition": "substitute, alternate"
     },
     {
+      "ID": "N4#153",
       "Kana": "かわる",
       "Kanji": "変わる",
       "Definition": "to change, to be transformed, to vary"
     },
     {
+      "ID": "N4#154",
       "Kana": "かんがえる",
       "Kanji": "考える",
       "Definition": "to consider"
     },
     {
+      "ID": "N4#155",
       "Kana": "かんけい",
       "Kanji": "関係",
       "Definition": "relation, connection"
     },
     {
+      "ID": "N4#156",
       "Kana": "かんごふ",
       "Kanji": "看護婦",
       "Definition": "(female) nurse"
     },
     {
+      "ID": "N4#157",
       "Kana": "かんたん",
       "Kanji": "簡単",
       "Definition": "simple"
@@ -798,26 +955,31 @@
   ],
   "が": [
     {
+      "ID": "N4#158",
       "Kana": "ガス",
       "Kanji": "",
       "Definition": "gas"
     },
     {
+      "ID": "N4#159",
       "Kana": "ガソリン",
       "Kanji": "",
       "Definition": "gasoline, petrol"
     },
     {
+      "ID": "N4#160",
       "Kana": "ガソリンスタンド",
       "Kanji": "",
       "Definition": "gasoline stand, gas station, petrol station"
     },
     {
+      "ID": "N4#161",
       "Kana": "ガラス",
       "Kanji": "",
       "Definition": "glass, pane"
     },
     {
+      "ID": "N4#162",
       "Kana": "がんばる",
       "Kanji": "頑張る",
       "Definition": "to try one's best, to persist"
@@ -825,121 +987,145 @@
   ],
   "き": [
     {
+      "ID": "N4#163",
       "Kana": "き",
       "Kanji": "気",
       "Definition": "spirit, mood"
     },
     {
+      "ID": "N4#164",
       "Kana": "きかい",
       "Kanji": "機会",
       "Definition": "chance, opportunity"
     },
     {
+      "ID": "N4#165",
       "Kana": "きけん",
       "Kanji": "危険",
       "Definition": "danger, peril, hazard"
     },
     {
+      "ID": "N4#166",
       "Kana": "きこえる",
       "Kanji": "聞こえる",
       "Definition": "to be heard, to be audible"
     },
     {
+      "ID": "N4#167",
       "Kana": "きしゃ",
       "Kanji": "汽車",
       "Definition": "train (steam)"
     },
     {
+      "ID": "N4#168",
       "Kana": "きせつ",
       "Kanji": "季節",
       "Definition": "season"
     },
     {
+      "ID": "N4#169",
       "Kana": "きそく",
       "Kanji": "規則",
       "Definition": "rule, regulations"
     },
     {
+      "ID": "N4#170",
       "Kana": "きっと",
       "Kanji": "",
       "Definition": "surely, definitely"
     },
     {
+      "ID": "N4#171",
       "Kana": "きぬ",
       "Kanji": "絹",
       "Definition": "silk"
     },
     {
+      "ID": "N4#172",
       "Kana": "きびしい",
       "Kanji": "厳しい",
       "Definition": "strict"
     },
     {
+      "ID": "N4#173",
       "Kana": "きぶん",
       "Kanji": "気分",
       "Definition": "feeling, mood"
     },
     {
+      "ID": "N4#174",
       "Kana": "きまる",
       "Kanji": "決る",
       "Definition": "to be decided, to be settled"
     },
     {
+      "ID": "N4#175",
       "Kana": "きみ",
       "Kanji": "君",
       "Definition": "You (masculine term for female)"
     },
     {
+      "ID": "N4#176",
       "Kana": "きめる",
       "Kanji": "決める",
       "Definition": "to decide"
     },
     {
+      "ID": "N4#177",
       "Kana": "きもち",
       "Kanji": "気持ち",
       "Definition": "feeling, sensation, mood"
     },
     {
+      "ID": "N4#178",
       "Kana": "きもの",
       "Kanji": "着物",
       "Definition": "kimono"
     },
     {
+      "ID": "N4#179",
       "Kana": "きゃく",
       "Kanji": "客",
       "Definition": "guest, customer"
     },
     {
+      "ID": "N4#180",
       "Kana": "きゅう",
       "Kanji": "急",
       "Definition": "(1) urgent, sudden, (2) steep"
     },
     {
+      "ID": "N4#181",
       "Kana": "きゅうこう",
       "Kanji": "急行",
       "Definition": "express (eg train that bypasses stations)"
     },
     {
+      "ID": "N4#182",
       "Kana": "きょういく",
       "Kanji": "教育",
       "Definition": "training, education"
     },
     {
+      "ID": "N4#183",
       "Kana": "きょうかい",
       "Kanji": "教会",
       "Definition": "church"
     },
     {
+      "ID": "N4#184",
       "Kana": "きょうそう",
       "Kanji": "競争",
       "Definition": "competition, contest"
     },
     {
+      "ID": "N4#185",
       "Kana": "きょうみ",
       "Kanji": "興味",
       "Definition": "interest (in something)"
     },
     {
+      "ID": "N4#186",
       "Kana": "きんじょ",
       "Kanji": "近所",
       "Definition": "neighbourhood"
@@ -947,6 +1133,7 @@
   ],
   "ぎ": [
     {
+      "ID": "N4#187",
       "Kana": "ぎじゅつ",
       "Kanji": "技術",
       "Definition": "art, technique, technology, skill"
@@ -954,46 +1141,55 @@
   ],
   "く": [
     {
+      "ID": "N4#188",
       "Kana": "くうき",
       "Kanji": "空気",
       "Definition": "air, atmosphere"
     },
     {
+      "ID": "N4#189",
       "Kana": "くうこう",
       "Kanji": "空港",
       "Definition": "airport"
     },
     {
+      "ID": "N4#190",
       "Kana": "くさ",
       "Kanji": "草",
       "Definition": "grass"
     },
     {
+      "ID": "N4#191",
       "Kana": "くださる",
       "Kanji": "",
       "Definition": "(hon) to give, to confer"
     },
     {
+      "ID": "N4#192",
       "Kana": "くび",
       "Kanji": "首",
       "Definition": "neck"
     },
     {
+      "ID": "N4#193",
       "Kana": "くも",
       "Kanji": "雲",
       "Definition": "cloud"
     },
     {
+      "ID": "N4#194",
       "Kana": "くらべる",
       "Kanji": "比べる",
       "Definition": "to compare"
     },
     {
+      "ID": "N4#195",
       "Kana": "くれる",
       "Kanji": "",
       "Definition": "to give, to do for"
     },
     {
+      "ID": "N4#196",
       "Kana": "くれる",
       "Kanji": "暮れる",
       "Definition": "to get dark, to come to an end"
@@ -1001,6 +1197,7 @@
   ],
   "ぐ": [
     {
+      "ID": "N4#197",
       "Kana": "ぐあい",
       "Kanji": "具合",
       "Definition": "condition, state, health"
@@ -1008,101 +1205,121 @@
   ],
   "け": [
     {
+      "ID": "N4#198",
       "Kana": "け",
       "Kanji": "毛",
       "Definition": "hair"
     },
     {
+      "ID": "N4#199",
       "Kana": "け",
       "Kanji": "毛",
       "Definition": "fur"
     },
     {
+      "ID": "N4#200",
       "Kana": "けいかく",
       "Kanji": "計画",
       "Definition": "plan, project, schedule"
     },
     {
+      "ID": "N4#201",
       "Kana": "けいかくする",
       "Kanji": "計画する",
       "Definition": "to plan, to schedule"
     },
     {
+      "ID": "N4#202",
       "Kana": "けいけん",
       "Kanji": "経験",
       "Definition": "experience"
     },
     {
+      "ID": "N4#203",
       "Kana": "けいけんする",
       "Kanji": "経験する",
       "Definition": "to experience or gain experience"
     },
     {
+      "ID": "N4#204",
       "Kana": "けいざい",
       "Kanji": "経済",
       "Definition": "economics, finance, economy"
     },
     {
+      "ID": "N4#205",
       "Kana": "けいさつ",
       "Kanji": "警察",
       "Definition": "police"
     },
     {
+      "ID": "N4#206",
       "Kana": "けが",
       "Kanji": "",
       "Definition": "injury (to animate object), hurt"
     },
     {
+      "ID": "N4#207",
       "Kana": "けがする",
       "Kanji": "",
       "Definition": "to injure (to animate object), to harm"
     },
     {
+      "ID": "N4#208",
       "Kana": "ケーキ",
       "Kanji": "",
       "Definition": "cake"
     },
     {
+      "ID": "N4#209",
       "Kana": "けしき",
       "Kanji": "景色",
       "Definition": "scenery, scene, landscape"
     },
     {
+      "ID": "N4#210",
       "Kana": "けしゴム",
       "Kanji": "消しゴム",
       "Definition": "eraser"
     },
     {
+      "ID": "N4#211",
       "Kana": "けっして",
       "Kanji": "決して",
       "Definition": "never"
     },
     {
+      "ID": "N4#212",
       "Kana": "けれど/けれども",
       "Kanji": "",
       "Definition": "but, however"
     },
     {
+      "ID": "N4#213",
       "Kana": "けんか",
       "Kanji": "",
       "Definition": "quarrel"
     },
     {
+      "ID": "N4#214",
       "Kana": "けんか・する",
       "Kanji": "",
       "Definition": "to quarrel"
     },
     {
+      "ID": "N4#215",
       "Kana": "けんきゅう",
       "Kanji": "研究",
       "Definition": "study, research, investigation"
     },
     {
+      "ID": "N4#216",
       "Kana": "けんきゅうしつ",
       "Kanji": "研究室",
       "Definition": "study room, laboratory"
     },
     {
+      "ID": "N4#217",
       "Kana": "けんぶつ",
       "Kanji": "見物",
       "Definition": "a sight, an attraction"
@@ -1110,16 +1327,19 @@
   ],
   "げ": [
     {
+      "ID": "N4#218",
       "Kana": "げしゅく",
       "Kanji": "下宿",
       "Definition": "boarding, lodging, boarding house"
     },
     {
+      "ID": "N4#219",
       "Kana": "げんいん",
       "Kanji": "原因",
       "Definition": "cause, origin, source"
     },
     {
+      "ID": "N4#220",
       "Kana": "げんかん",
       "Kanji": "玄関",
       "Definition": "entrance way (in Japanese house)"
@@ -1127,176 +1347,211 @@
   ],
   "こ": [
     {
+      "ID": "N4#221",
       "Kana": "こ",
       "Kanji": "子",
       "Definition": "child"
     },
     {
+      "ID": "N4#222",
       "Kana": "こう",
       "Kanji": "",
       "Definition": "like this, this way"
     },
     {
+      "ID": "N4#223",
       "Kana": "こうがい",
       "Kanji": "郊外",
       "Definition": "suburb, outskirts"
     },
     {
+      "ID": "N4#224",
       "Kana": "こうぎ",
       "Kanji": "講義",
       "Definition": "lecture"
     },
     {
+      "ID": "N4#225",
       "Kana": "こうぎょう",
       "Kanji": "工業",
       "Definition": "(manufacturing) industry"
     },
     {
+      "ID": "N4#226",
       "Kana": "こうこう",
       "Kanji": "高校",
       "Definition": "high school"
     },
     {
+      "ID": "N4#227",
       "Kana": "こうとうがっこう",
       "Kanji": "高等学校",
       "Definition": "senior high school"
     },
     {
+      "ID": "N4#228",
       "Kana": "こうこうせい",
       "Kanji": "高校生",
       "Definition": "high school student"
     },
     {
+      "ID": "N4#229",
       "Kana": "こうじょう",
       "Kanji": "工場",
       "Definition": "factory"
     },
     {
+      "ID": "N4#230",
       "Kana": "こうちょう",
       "Kanji": "校長",
       "Definition": "principal, headmaster"
     },
     {
+      "ID": "N4#231",
       "Kana": "こうつう",
       "Kanji": "交通",
       "Definition": "traffic, transportation"
     },
     {
+      "ID": "N4#232",
       "Kana": "こうどう",
       "Kanji": "講堂",
       "Definition": "auditorium"
     },
     {
+      "ID": "N4#233",
       "Kana": "こうむいん",
       "Kanji": "公務員",
       "Definition": "government worker, public servant"
     },
     {
+      "ID": "N4#234",
       "Kana": "こくさい",
       "Kanji": "国際",
       "Definition": "international"
     },
     {
+      "ID": "N4#235",
       "Kana": "こころ",
       "Kanji": "心",
       "Definition": "core, heart"
     },
     {
+      "ID": "N4#236",
       "Kana": "こしょう",
       "Kanji": "故障",
       "Definition": "break-down"
     },
     {
+      "ID": "N4#237",
       "Kana": "こしょうする",
       "Kanji": "故障する",
       "Definition": "to break-down"
     },
     {
+      "ID": "N4#238",
       "Kana": "こたえ",
       "Kanji": "答",
       "Definition": "answer, response"
     },
     {
+      "ID": "N4#239",
       "Kana": "こっち",
       "Kanji": "",
       "Definition": "(1) this person, (2) this direction, (3) this side, (4) thereafter"
     },
     {
+      "ID": "N4#240",
       "Kana": "こと",
       "Kanji": "",
       "Definition": "thing, matter, fact"
     },
     {
+      "ID": "N4#241",
       "Kana": "ことり",
       "Kanji": "小鳥",
       "Definition": "small bird"
     },
     {
+      "ID": "N4#242",
       "Kana": "このあいだ",
       "Kanji": "",
       "Definition": "the other day, recently"
     },
     {
+      "ID": "N4#243",
       "Kana": "このごろ",
       "Kanji": "",
       "Definition": "these days, nowadays"
     },
     {
+      "ID": "N4#244",
       "Kana": "こまかい",
       "Kanji": "細かい",
       "Definition": "(1) small, (2) fine, minute"
     },
     {
+      "ID": "N4#245",
       "Kana": "こむ",
       "Kanji": "込む",
       "Definition": "to be crowded"
     },
     {
+      "ID": "N4#246",
       "Kana": "こめ",
       "Kanji": "米",
       "Definition": "uncooked rice"
     },
     {
+      "ID": "N4#247",
       "Kana": "これから",
       "Kanji": "",
       "Definition": "after this"
     },
     {
+      "ID": "N4#248",
       "Kana": "こわい",
       "Kanji": "怖い",
       "Definition": "scary, frightening"
     },
     {
+      "ID": "N4#249",
       "Kana": "こわす",
       "Kanji": "壊す",
       "Definition": "to break, to break down"
     },
     {
+      "ID": "N4#250",
       "Kana": "こわれる",
       "Kanji": "壊れる",
       "Definition": "to be broken, to break"
     },
     {
+      "ID": "N4#251",
       "Kana": "コンサート",
       "Kanji": "",
       "Definition": "concert"
     },
     {
+      "ID": "N4#252",
       "Kana": "こんど",
       "Kanji": "今度",
       "Definition": "now, next time"
     },
     {
+      "ID": "N4#253",
       "Kana": "コンピュータ",
       "Kanji": "",
       "Definition": "computer"
     },
     {
+      "ID": "N4#254",
       "Kana": "コンピューター",
       "Kanji": "",
       "Definition": "computer"
     },
     {
+      "ID": "N4#255",
       "Kana": "こんや",
       "Kanji": "今夜",
       "Definition": "this evening, tonight"
@@ -1304,26 +1559,31 @@
   ],
   "ご": [
     {
+      "ID": "N4#256",
       "Kana": "ごしゅじん",
       "Kanji": "ご主人",
       "Definition": "your husband, her husband"
     },
     {
+      "ID": "N4#257",
       "Kana": "ごぞんじ",
       "Kanji": "ご存じ",
       "Definition": "knowing, acquaintance"
     },
     {
+      "ID": "N4#258",
       "Kana": "ごちそう",
       "Kanji": "",
       "Definition": "feast, treating (someone)"
     },
     {
+      "ID": "N4#259",
       "Kana": "ごみ",
       "Kanji": "",
       "Definition": "rubbish, trash, garbage"
     },
     {
+      "ID": "N4#260",
       "Kana": "ごらんになる",
       "Kanji": "",
       "Definition": "(hon) to see"
@@ -1331,96 +1591,115 @@
   ],
   "さ": [
     {
+      "ID": "N4#261",
       "Kana": "さいきん",
       "Kanji": "最近",
       "Definition": "latest, most recent, nowadays"
     },
     {
+      "ID": "N4#262",
       "Kana": "さいご",
       "Kanji": "最後",
       "Definition": "last, end, conclusion"
     },
     {
+      "ID": "N4#263",
       "Kana": "さいしょ",
       "Kanji": "最初",
       "Definition": "beginning, first"
     },
     {
+      "ID": "N4#264",
       "Kana": "さか",
       "Kanji": "坂",
       "Definition": "slope, hill"
     },
     {
+      "ID": "N4#265",
       "Kana": "さがす",
       "Kanji": "探す",
       "Definition": "to search, to seek, to look for"
     },
     {
+      "ID": "N4#266",
       "Kana": "さがる",
       "Kanji": "下る",
       "Definition": "to get down, to descend"
     },
     {
+      "ID": "N4#267",
       "Kana": "さかん",
       "Kanji": "盛ん",
       "Definition": "popularity, prosperous"
     },
     {
+      "ID": "N4#268",
       "Kana": "さげる",
       "Kanji": "下げる",
       "Definition": "to hang, to lower, to move back"
     },
     {
+      "ID": "N4#269",
       "Kana": "さしあげる",
       "Kanji": "差し上げる",
       "Definition": "(polite) to give, to offer"
     },
     {
+      "ID": "N4#270",
       "Kana": "さっき",
       "Kanji": "",
       "Definition": "some time ago"
     },
     {
+      "ID": "N4#271",
       "Kana": "さびしい",
       "Kanji": "寂しい",
       "Definition": "lonely, lonesome"
     },
     {
+      "ID": "N4#272",
       "Kana": "さらいげつ",
       "Kanji": "さ来月",
       "Definition": "the month after next"
     },
     {
+      "ID": "N4#273",
       "Kana": "さらいしゅう",
       "Kanji": "さ来週",
       "Definition": "the week after next"
     },
     {
+      "ID": "N4#274",
       "Kana": "サラダ",
       "Kanji": "",
       "Definition": "salad"
     },
     {
+      "ID": "N4#275",
       "Kana": "さわぐ",
       "Kanji": "騒ぐ",
       "Definition": "to make noise, to clamor, to be excited"
     },
     {
+      "ID": "N4#276",
       "Kana": "さわる",
       "Kanji": "触る",
       "Definition": "to touch, to feel"
     },
     {
+      "ID": "N4#277",
       "Kana": "さんぎょう",
       "Kanji": "産業",
       "Definition": "industry"
     },
     {
+      "ID": "N4#278",
       "Kana": "サンダル",
       "Kanji": "",
       "Definition": "sandal"
     },
     {
+      "ID": "N4#279",
       "Kana": "サンドイッチ",
       "Kanji": "",
       "Definition": "sandwich"
@@ -1428,6 +1707,7 @@
   ],
   "ざ": [
     {
+      "ID": "N4#280",
       "Kana": "ざんねん",
       "Kanji": "残念",
       "Definition": "bad luck, disappointment"
@@ -1435,206 +1715,247 @@
   ],
   "し": [
     {
+      "ID": "N4#281",
       "Kana": "し",
       "Kanji": "市",
       "Definition": "city"
     },
     {
+      "ID": "N4#282",
       "Kana": "しあい",
       "Kanji": "試合",
       "Definition": "match, game, contest"
     },
     {
+      "ID": "N4#283",
       "Kana": "しかた",
       "Kanji": "仕方",
       "Definition": "way, method"
     },
     {
+      "ID": "N4#284",
       "Kana": "しかる",
       "Kanji": "",
       "Definition": "to scold"
     },
     {
+      "ID": "N4#285",
       "Kana": "しけん",
       "Kanji": "試験",
       "Definition": "examination, test, study"
     },
     {
+      "ID": "N4#286",
       "Kana": "したぎ",
       "Kanji": "下着",
       "Definition": "underwear"
     },
     {
+      "ID": "N4#287",
       "Kana": "したく",
       "Kanji": "支度",
       "Definition": "preparation"
     },
     {
+      "ID": "N4#288",
       "Kana": "したくする",
       "Kanji": "支度する",
       "Definition": "to prepare"
     },
     {
+      "ID": "N4#289",
       "Kana": "しっかり",
       "Kanji": "",
       "Definition": "firmly, tightly, steady"
     },
     {
+      "ID": "N4#290",
       "Kana": "しっぱい",
       "Kanji": "失敗",
       "Definition": "failure, mistake, blunder"
     },
     {
+      "ID": "N4#291",
       "Kana": "しつれい",
       "Kanji": "失礼",
       "Definition": "(1) discourtesy, impoliteness, (2) Excuse me, Goodbye"
     },
     {
+      "ID": "N4#292",
       "Kana": "しなもの",
       "Kanji": "品物",
       "Definition": "goods"
     },
     {
+      "ID": "N4#293",
       "Kana": "しばらく",
       "Kanji": "",
       "Definition": "little while"
     },
     {
+      "ID": "N4#294",
       "Kana": "しま",
       "Kanji": "島",
       "Definition": "island"
     },
     {
+      "ID": "N4#295",
       "Kana": "しみん",
       "Kanji": "市民",
       "Definition": "citizen"
     },
     {
+      "ID": "N4#296",
       "Kana": "しゃかい",
       "Kanji": "社会",
       "Definition": "society, public"
     },
     {
+      "ID": "N4#297",
       "Kana": "しゃちょう",
       "Kanji": "社長",
       "Definition": "company president, manager, director"
     },
     {
+      "ID": "N4#298",
       "Kana": "しゅうかん",
       "Kanji": "習慣",
       "Definition": "custom, habit, manners"
     },
     {
+      "ID": "N4#299",
       "Kana": "しゅっせき",
       "Kanji": "出席",
       "Definition": "attendance, presence"
     },
     {
+      "ID": "N4#300",
       "Kana": "しゅっせきする",
       "Kanji": "出席する",
       "Definition": "to attend, to be present"
     },
     {
+      "ID": "N4#301",
       "Kana": "しゅっぱつ",
       "Kanji": "出発",
       "Definition": "departure"
     },
     {
+      "ID": "N4#302",
       "Kana": "しゅっぱつする",
       "Kanji": "出発する",
       "Definition": "to depart"
     },
     {
+      "ID": "N4#303",
       "Kana": "しゅみ",
       "Kanji": "趣味",
       "Definition": "hobby"
     },
     {
+      "ID": "N4#304",
       "Kana": "しょうかい",
       "Kanji": "紹介",
       "Definition": "introduction"
     },
     {
+      "ID": "N4#305",
       "Kana": "しょうがつ",
       "Kanji": "正月",
       "Definition": "New Year, New Year's Day"
     },
     {
+      "ID": "N4#306",
       "Kana": "しょうがっこう",
       "Kanji": "小学校",
       "Definition": "primary school, elementary school"
     },
     {
+      "ID": "N4#307",
       "Kana": "しょうせつ",
       "Kanji": "小説",
       "Definition": "novel, story"
     },
     {
+      "ID": "N4#308",
       "Kana": "しょうたい",
       "Kanji": "招待",
       "Definition": "invitation"
     },
     {
+      "ID": "N4#309",
       "Kana": "しょうたいする",
       "Kanji": "招待する",
       "Definition": "to invite"
     },
     {
+      "ID": "N4#310",
       "Kana": "しょうち",
       "Kanji": "承知",
       "Definition": "consent, acceptance"
     },
     {
+      "ID": "N4#311",
       "Kana": "しょうちする",
       "Kanji": "承知する",
       "Definition": "to consent, to acceptance"
     },
     {
+      "ID": "N4#312",
       "Kana": "しょうらい",
       "Kanji": "将来",
       "Definition": "future, prospects"
     },
     {
+      "ID": "N4#313",
       "Kana": "しょくじ",
       "Kanji": "食事",
       "Definition": "meal"
     },
     {
+      "ID": "N4#314",
       "Kana": "しょくじする",
       "Kanji": "食事",
       "Definition": "to grab a meal, to eat"
     },
     {
+      "ID": "N4#315",
       "Kana": "しょくりょうひん",
       "Kanji": "食料品",
       "Definition": "foodstuff, groceries"
     },
     {
+      "ID": "N4#316",
       "Kana": "しらせる",
       "Kanji": "知らせる",
       "Definition": "to notify, to advise"
     },
     {
+      "ID": "N4#317",
       "Kana": "しらべる",
       "Kanji": "調べる",
       "Definition": "to investigate, to check up"
     },
     {
+      "ID": "N4#318",
       "Kana": "しんせつ",
       "Kanji": "親切",
       "Definition": "kindness, gentleness"
     },
     {
+      "ID": "N4#319",
       "Kana": "しんぱい",
       "Kanji": "心配",
       "Definition": "worry, concern"
     },
     {
+      "ID": "N4#320",
       "Kana": "しんぱいする",
       "Kanji": "心配する",
       "Definition": "to worry, to concern"
     },
     {
+      "ID": "N4#321",
       "Kana": "しんぶんしゃ",
       "Kanji": "新聞社",
       "Definition": "newspaper company"
@@ -1642,86 +1963,103 @@
   ],
   "じ": [
     {
+      "ID": "N4#322",
       "Kana": "じ",
       "Kanji": "字",
       "Definition": "character, hand-writing"
     },
     {
+      "ID": "N4#323",
       "Kana": "じこ",
       "Kanji": "事故",
       "Definition": "accident"
     },
     {
+      "ID": "N4#324",
       "Kana": "じしん",
       "Kanji": "地震",
       "Definition": "earthquake"
     },
     {
+      "ID": "N4#325",
       "Kana": "じだい",
       "Kanji": "時代",
       "Definition": "period, epoch, era"
     },
     {
+      "ID": "N4#326",
       "Kana": "じてん",
       "Kanji": "辞典",
       "Definition": "dictionary"
     },
     {
+      "ID": "N4#327",
       "Kana": "じむしょ",
       "Kanji": "事務所",
       "Definition": "office"
     },
     {
+      "ID": "N4#328",
       "Kana": "じゃま",
       "Kanji": "",
       "Definition": "hindrance, intrusion"
     },
     {
+      "ID": "N4#329",
       "Kana": "ジャム",
       "Kanji": "",
       "Definition": "jam"
     },
     {
+      "ID": "N4#330",
       "Kana": "じゆう",
       "Kanji": "自由",
       "Definition": "freedom"
     },
     {
+      "ID": "N4#331",
       "Kana": "じゅうしょ",
       "Kanji": "住所",
       "Definition": "address (eg of house), residence, domicile"
     },
     {
+      "ID": "N4#332",
       "Kana": "じゅうどう",
       "Kanji": "柔道",
       "Definition": "judo"
     },
     {
+      "ID": "N4#333",
       "Kana": "じゅうぶん",
       "Kanji": "十分",
       "Definition": "enough , sufficient"
     },
     {
+      "ID": "N4#334",
       "Kana": "じゅんび",
       "Kanji": "準備",
       "Definition": "prepare"
     },
     {
+      "ID": "N4#335",
       "Kana": "じゅんびする",
       "Kanji": "準備する",
       "Definition": "to prepare"
     },
     {
+      "ID": "N4#336",
       "Kana": "じょせい",
       "Kanji": "女性",
       "Definition": "woman"
     },
     {
+      "ID": "N4#337",
       "Kana": "じんこう",
       "Kanji": "人口",
       "Definition": "population"
     },
     {
+      "ID": "N4#338",
       "Kana": "じんじゃ",
       "Kanji": "神社",
       "Definition": "Shinto shrine"
@@ -1729,116 +2067,139 @@
   ],
   "す": [
     {
+      "ID": "N4#339",
       "Kana": "すいえい",
       "Kanji": "水泳",
       "Definition": "swimming"
     },
     {
+      "ID": "N4#340",
       "Kana": "すいどう",
       "Kanji": "水道",
       "Definition": "water service, water supply"
     },
     {
+      "ID": "N4#341",
       "Kana": "すうがく",
       "Kanji": "数学",
       "Definition": "mathematics, arithmetic"
     },
     {
+      "ID": "N4#342",
       "Kana": "スーツ",
       "Kanji": "",
       "Definition": "suit"
     },
     {
+      "ID": "N4#343",
       "Kana": "スーツケース",
       "Kanji": "",
       "Definition": "suitcase"
     },
     {
+      "ID": "N4#344",
       "Kana": "スーパー",
       "Kanji": "",
       "Definition": "supermarket"
     },
     {
+      "ID": "N4#345",
       "Kana": "すぎる",
       "Kanji": "過ぎる",
       "Definition": "to exceed, to go beyond"
     },
     {
+      "ID": "N4#346",
       "Kana": "すく",
       "Kanji": "",
       "Definition": "to become empty"
     },
     {
+      "ID": "N4#347",
       "Kana": "すく",
       "Kanji": "",
       "Definition": "to be less crowded"
     },
     {
+      "ID": "N4#348",
       "Kana": "スクリーン",
       "Kanji": "",
       "Definition": "screen"
     },
     {
+      "ID": "N4#349",
       "Kana": "すごい",
       "Kanji": "凄い",
       "Definition": "terrific, amazing, to a great extent"
     },
     {
+      "ID": "N4#350",
       "Kana": "すすむ",
       "Kanji": "進む",
       "Definition": "to make progress, to advance, to proceed"
     },
     {
+      "ID": "N4#351",
       "Kana": "すっかり",
       "Kanji": "",
       "Definition": "all, completely, thoroughly"
     },
     {
+      "ID": "N4#352",
       "Kana": "ステーキ",
       "Kanji": "",
       "Definition": "steak"
     },
     {
+      "ID": "N4#353",
       "Kana": "ステレオ",
       "Kanji": "",
       "Definition": "stereo"
     },
     {
+      "ID": "N4#354",
       "Kana": "すてる",
       "Kanji": "捨てる",
       "Definition": "to throw away"
     },
     {
+      "ID": "N4#355",
       "Kana": "すな",
       "Kanji": "砂",
       "Definition": "sand"
     },
     {
+      "ID": "N4#356",
       "Kana": "すばらしい",
       "Kanji": "",
       "Definition": "wonderful, splendid"
     },
     {
+      "ID": "N4#357",
       "Kana": "すべる",
       "Kanji": "滑る",
       "Definition": "to slide, to slip"
     },
     {
+      "ID": "N4#358",
       "Kana": "すみ",
       "Kanji": "隅",
       "Definition": "corner, nook"
     },
     {
+      "ID": "N4#359",
       "Kana": "すむ",
       "Kanji": "済む",
       "Definition": "to finish, to end"
     },
     {
+      "ID": "N4#360",
       "Kana": "すり",
       "Kanji": "",
       "Definition": "pickpocket"
     },
     {
+      "ID": "N4#361",
       "Kana": "すると",
       "Kanji": "",
       "Definition": "and, then"
@@ -1846,11 +2207,13 @@
   ],
   "ず": [
     {
+      "ID": "N4#362",
       "Kana": "ずいぶん",
       "Kanji": "",
       "Definition": "extremely"
     },
     {
+      "ID": "N4#363",
       "Kana": "ずっと",
       "Kanji": "",
       "Definition": "straight, quickly, all of a sudden"
@@ -1858,81 +2221,97 @@
   ],
   "せ": [
     {
+      "ID": "N4#364",
       "Kana": "せいかつ",
       "Kanji": "生活",
       "Definition": "living, life (one's daily existence), livelihood"
     },
     {
+      "ID": "N4#365",
       "Kana": "せいかつする",
       "Kanji": "生活する",
       "Definition": "to live (one's daily existence)"
     },
     {
+      "ID": "N4#366",
       "Kana": "せいさん",
       "Kanji": "生産",
       "Definition": "production, manufacture"
     },
     {
+      "ID": "N4#367",
       "Kana": "せいさんする",
       "Kanji": "生産する",
       "Definition": "to produce, to manufacture"
     },
     {
+      "ID": "N4#368",
       "Kana": "せいじ",
       "Kanji": "政治",
       "Definition": "politics, government"
     },
     {
+      "ID": "N4#369",
       "Kana": "せいよう",
       "Kanji": "西洋",
       "Definition": "the west, Western countries"
     },
     {
+      "ID": "N4#370",
       "Kana": "せかい",
       "Kanji": "世界",
       "Definition": "the world"
     },
     {
+      "ID": "N4#371",
       "Kana": "せき",
       "Kanji": "席",
       "Definition": "seat"
     },
     {
+      "ID": "N4#372",
       "Kana": "せつめい",
       "Kanji": "説明",
       "Definition": "explanation"
     },
     {
+      "ID": "N4#373",
       "Kana": "せなか",
       "Kanji": "背中",
       "Definition": "back (of body)"
     },
     {
+      "ID": "N4#374",
       "Kana": "せわ",
       "Kanji": "世話",
       "Definition": "looking after, help"
     },
     {
+      "ID": "N4#375",
       "Kana": "せわする",
       "Kanji": "世話する",
       "Definition": "to look after, to help"
     },
     {
+      "ID": "N4#376",
       "Kana": "せん",
       "Kanji": "線",
       "Definition": "line, wire"
     },
     {
+      "ID": "N4#377",
       "Kana": "せんそう",
       "Kanji": "戦争",
       "Definition": "war"
     },
     {
+      "ID": "N4#378",
       "Kana": "せんぱい",
       "Kanji": "先輩",
       "Definition": "senior, superior, elder"
     },
     {
+      "ID": "N4#379",
       "Kana": "せんもん",
       "Kanji": "専門",
       "Definition": "speciality, study major"
@@ -1940,11 +2319,13 @@
   ],
   "ぜ": [
     {
+      "ID": "N4#380",
       "Kana": "ぜひ",
       "Kanji": "",
       "Definition": "certainly, without fail"
     },
     {
+      "ID": "N4#381",
       "Kana": "ぜんぜん",
       "Kanji": "",
       "Definition": "wholly, entirely"
@@ -1952,66 +2333,79 @@
   ],
   "そ": [
     {
+      "ID": "N4#382",
       "Kana": "そうだん",
       "Kanji": "相談",
       "Definition": "consultation, discussion"
     },
     {
+      "ID": "N4#383",
       "Kana": "そうだんする",
       "Kanji": "相談する",
       "Definition": "to consult, to discuss"
     },
     {
+      "ID": "N4#384",
       "Kana": "そだてる",
       "Kanji": "育てる",
       "Definition": "to raise, to rear, to bring up"
     },
     {
+      "ID": "N4#385",
       "Kana": "そつぎょう",
       "Kanji": "卒業",
       "Definition": "graduation"
     },
     {
+      "ID": "N4#386",
       "Kana": "そふ",
       "Kanji": "祖父",
       "Definition": "grandfather"
     },
     {
+      "ID": "N4#387",
       "Kana": "ソフト",
       "Kanji": "",
       "Definition": "soft"
     },
     {
+      "ID": "N4#388",
       "Kana": "そぼ",
       "Kanji": "祖母",
       "Definition": "grandmother"
     },
     {
+      "ID": "N4#389",
       "Kana": "それで",
       "Kanji": "",
       "Definition": "and, thereupon, because of that"
     },
     {
+      "ID": "N4#390",
       "Kana": "それに",
       "Kanji": "",
       "Definition": "besides, moreover"
     },
     {
+      "ID": "N4#391",
       "Kana": "それほど",
       "Kanji": "",
       "Definition": "to that degree, extent"
     },
     {
+      "ID": "N4#392",
       "Kana": "そろそろ",
       "Kanji": "",
       "Definition": "gradually, steadily, soon"
     },
     {
+      "ID": "N4#393",
       "Kana": "そんな",
       "Kanji": "",
       "Definition": "such, like that, that sort of"
     },
     {
+      "ID": "N4#394",
       "Kana": "そんなに",
       "Kanji": "",
       "Definition": "so much, like that"
@@ -2019,106 +2413,127 @@
   ],
   "た": [
     {
+      "ID": "N4#395",
       "Kana": "たいいん",
       "Kanji": "退院",
       "Definition": "leaving hospital"
     },
     {
+      "ID": "N4#396",
       "Kana": "たいいんする",
       "Kanji": "退院する",
       "Definition": "to leave the hospital"
     },
     {
+      "ID": "N4#397",
       "Kana": "たいてい",
       "Kanji": "",
       "Definition": "generally, usually"
     },
     {
+      "ID": "N4#398",
       "Kana": "タイプ",
       "Kanji": "",
       "Definition": "type, style"
     },
     {
+      "ID": "N4#399",
       "Kana": "たいふう",
       "Kanji": "台風",
       "Definition": "typhoon"
     },
     {
+      "ID": "N4#400",
       "Kana": "たおれる",
       "Kanji": "倒れる",
       "Definition": "to collapse, to break down"
     },
     {
+      "ID": "N4#401",
       "Kana": "たしか",
       "Kanji": "確か",
       "Definition": "certain, sure, definite"
     },
     {
+      "ID": "N4#402",
       "Kana": "たす",
       "Kanji": "足す",
       "Definition": "to add (numbers), to do (eg. one's business)"
     },
     {
+      "ID": "N4#403",
       "Kana": "たずねる",
       "Kanji": "訪ねる",
       "Definition": "to visit"
     },
     {
+      "ID": "N4#404",
       "Kana": "たずねる",
       "Kanji": "尋ねる",
       "Definition": "to ask"
     },
     {
+      "ID": "N4#405",
       "Kana": "ただしい",
       "Kanji": "正しい",
       "Definition": "right, just, correct"
     },
     {
+      "ID": "N4#406",
       "Kana": "たたみ",
       "Kanji": "畳",
       "Definition": "tatami mat (Japanese straw mat)"
     },
     {
+      "ID": "N4#407",
       "Kana": "たてる",
       "Kanji": "立てる",
       "Definition": "to stand (something) up, to erect (something)"
     },
     {
+      "ID": "N4#408",
       "Kana": "たてる",
       "Kanji": "建てる",
       "Definition": "to build, to construct"
     },
     {
+      "ID": "N4#409",
       "Kana": "たとえば",
       "Kanji": "例えば",
       "Definition": "for example, eg."
     },
     {
+      "ID": "N4#410",
       "Kana": "たな",
       "Kanji": "棚",
       "Definition": "shelves, rack"
     },
     {
+      "ID": "N4#411",
       "Kana": "たのしむ",
       "Kanji": "楽む",
       "Definition": "to enjoy oneself"
     },
     {
+      "ID": "N4#412",
       "Kana": "たのしみ",
       "Kanji": "楽しみ",
       "Definition": "pleasure, joy"
     },
     {
+      "ID": "N4#413",
       "Kana": "たまに",
       "Kanji": "",
       "Definition": "occasionally, once in a while"
     },
     {
+      "ID": "N4#414",
       "Kana": "ため",
       "Kanji": "為",
       "Definition": "good, advantage, in order to"
     },
     {
+      "ID": "N4#415",
       "Kana": "たりる",
       "Kanji": "足りる",
       "Definition": "to be sufficient, to be enough"
@@ -2126,41 +2541,49 @@
   ],
   "だ": [
     {
+      "ID": "N4#416",
       "Kana": "だいがくせい",
       "Kanji": "大学生",
       "Definition": "college student, university student"
     },
     {
+      "ID": "N4#417",
       "Kana": "だいじ",
       "Kanji": "大事",
       "Definition": "important, valuable, serious matter"
     },
     {
+      "ID": "N4#418",
       "Kana": "だいたい",
       "Kanji": "大体",
       "Definition": "generally, substantially"
     },
     {
+      "ID": "N4#419",
       "Kana": "だいぶ",
       "Kanji": "大分",
       "Definition": "considerably, greatly, a lot"
     },
     {
+      "ID": "N4#420",
       "Kana": "だから",
       "Kanji": "",
       "Definition": "so, therefore"
     },
     {
+      "ID": "N4#421",
       "Kana": "だめ",
       "Kanji": "",
       "Definition": "useless, no good, hopeless"
     },
     {
+      "ID": "N4#422",
       "Kana": "だんせい",
       "Kanji": "男性",
       "Definition": "male, man"
     },
     {
+      "ID": "N4#423",
       "Kana": "だんぼう",
       "Kanji": "暖房",
       "Definition": "heating"
@@ -2168,51 +2591,61 @@
   ],
   "ち": [
     {
+      "ID": "N4#424",
       "Kana": "ち",
       "Kanji": "血",
       "Definition": "blood"
     },
     {
+      "ID": "N4#425",
       "Kana": "チェック",
       "Kanji": "",
       "Definition": "check"
     },
     {
+      "ID": "N4#426",
       "Kana": "チェックする",
       "Kanji": "",
       "Definition": "to check"
     },
     {
+      "ID": "N4#427",
       "Kana": "ちから",
       "Kanji": "力",
       "Definition": "strength, power"
     },
     {
+      "ID": "N4#428",
       "Kana": "ちっとも",
       "Kanji": "",
       "Definition": "not at all (neg. verb)"
     },
     {
+      "ID": "N4#429",
       "Kana": "ちゅうい",
       "Kanji": "注意",
       "Definition": "caution, being careful, attention (heed)"
     },
     {
+      "ID": "N4#430",
       "Kana": "ちゅうがっこう",
       "Kanji": "中学校",
       "Definition": "junior high school, middle school pupil"
     },
     {
+      "ID": "N4#431",
       "Kana": "ちゅうしゃ",
       "Kanji": "注射",
       "Definition": "injection"
     },
     {
+      "ID": "N4#432",
       "Kana": "ちゅうしゃじょう",
       "Kanji": "駐車場",
       "Definition": "parking lot, parking place"
     },
     {
+      "ID": "N4#433",
       "Kana": "ちり",
       "Kanji": "地理",
       "Definition": "geography"
@@ -2220,71 +2653,85 @@
   ],
   "つ": [
     {
+      "ID": "N4#434",
       "Kana": "つかまえる",
       "Kanji": "捕まえる",
       "Definition": "to catch, to arrest, to seize"
     },
     {
+      "ID": "N4#435",
       "Kana": "つき",
       "Kanji": "",
       "Definition": "moon"
     },
     {
+      "ID": "N4#436",
       "Kana": "つく",
       "Kanji": "点く",
       "Definition": "to be started, to be switched on"
     },
     {
+      "ID": "N4#437",
       "Kana": "つける",
       "Kanji": "",
       "Definition": "to take"
     },
     {
+      "ID": "N4#438",
       "Kana": "つける",
       "Kanji": "漬ける",
       "Definition": "to soak, to moisten, to pickle"
     },
     {
+      "ID": "N4#439",
       "Kana": "つごう",
       "Kanji": "都合",
       "Definition": "circumstances, condition, convenience"
     },
     {
+      "ID": "N4#440",
       "Kana": "つたえる",
       "Kanji": "伝える",
       "Definition": "to tell, to report"
     },
     {
+      "ID": "N4#441",
       "Kana": "つづく",
       "Kanji": "続く",
       "Definition": "to be continued"
     },
     {
+      "ID": "N4#442",
       "Kana": "つづける",
       "Kanji": "続ける",
       "Definition": "to continue, to keep up, to keep on"
     },
     {
+      "ID": "N4#443",
       "Kana": "つつむ",
       "Kanji": "包む",
       "Definition": "wrap, pack"
     },
     {
+      "ID": "N4#444",
       "Kana": "つま",
       "Kanji": "妻",
       "Definition": "(hum) wife"
     },
     {
+      "ID": "N4#445",
       "Kana": "つもり",
       "Kanji": "",
       "Definition": "intention, plan"
     },
     {
+      "ID": "N4#446",
       "Kana": "つる",
       "Kanji": "釣る",
       "Definition": "to fish"
     },
     {
+      "ID": "N4#447",
       "Kana": "つれる",
       "Kanji": "連れる",
       "Definition": "to lead, to take (a person)"
@@ -2292,56 +2739,67 @@
   ],
   "て": [
     {
+      "ID": "N4#448",
       "Kana": "ていねい",
       "Kanji": "丁寧",
       "Definition": "polite, courteous"
     },
     {
+      "ID": "N4#449",
       "Kana": "テキスト",
       "Kanji": "",
       "Definition": "(1)text, (2)text book"
     },
     {
+      "ID": "N4#450",
       "Kana": "てきとう",
       "Kanji": "適当",
       "Definition": "fitness, suitability"
     },
     {
+      "ID": "N4#451",
       "Kana": "てつだう",
       "Kanji": "手伝う",
       "Definition": "to help, to assist, to take part in"
     },
     {
+      "ID": "N4#452",
       "Kana": "テニス",
       "Kanji": "",
       "Definition": "tennis"
     },
     {
+      "ID": "N4#453",
       "Kana": "てぶくろ",
       "Kanji": "手袋",
       "Definition": "glove"
     },
     {
+      "ID": "N4#454",
       "Kana": "てら",
       "Kanji": "寺",
       "Definition": "temple"
     },
     {
+      "ID": "N4#455",
       "Kana": "てん",
       "Kanji": "点",
       "Definition": "spot, mark, point, dot"
     },
     {
+      "ID": "N4#456",
       "Kana": "てんいん",
       "Kanji": "店員",
       "Definition": "shop assistant, employee, clerk, salesperson"
     },
     {
+      "ID": "N4#457",
       "Kana": "てんきよほう",
       "Kanji": "天気予報",
       "Definition": "weather forecast, weather report"
     },
     {
+      "ID": "N4#458",
       "Kana": "てんらんかい",
       "Kanji": "展覧会",
       "Definition": "exhibition"
@@ -2349,21 +2807,25 @@
   ],
   "で": [
     {
+      "ID": "N4#459",
       "Kana": "できる",
       "Kanji": "",
       "Definition": "to be able to do"
     },
     {
+      "ID": "N4#460",
       "Kana": "できるだけ",
       "Kanji": "",
       "Definition": "if at all possible, as much as possible"
     },
     {
+      "ID": "N4#461",
       "Kana": "でんとう",
       "Kanji": "電灯",
       "Definition": "electric light"
     },
     {
+      "ID": "N4#462",
       "Kana": "でんぽう",
       "Kanji": "電報",
       "Definition": "telegram"
@@ -2371,71 +2833,85 @@
   ],
   "と": [
     {
+      "ID": "N4#463",
       "Kana": "と",
       "Kanji": "都",
       "Definition": "metroplitan, municipal"
     },
     {
+      "ID": "N4#464",
       "Kana": "とうとう",
       "Kanji": "",
       "Definition": "finally, at last"
     },
     {
+      "ID": "N4#465",
       "Kana": "とおく",
       "Kanji": "遠く",
       "Definition": "far away, distant"
     },
     {
+      "ID": "N4#466",
       "Kana": "とおり",
       "Kanji": "通り",
       "Definition": "～ Street, ～ Avenue"
     },
     {
+      "ID": "N4#467",
       "Kana": "とおる",
       "Kanji": "通る",
       "Definition": "to pass (by), to go through"
     },
     {
+      "ID": "N4#468",
       "Kana": "とくに",
       "Kanji": "特に",
       "Definition": "particularly, especially"
     },
     {
+      "ID": "N4#469",
       "Kana": "とくべつ",
       "Kanji": "特別",
       "Definition": "special"
     },
     {
+      "ID": "N4#470",
       "Kana": "とこや",
       "Kanji": "",
       "Definition": "barber"
     },
     {
+      "ID": "N4#471",
       "Kana": "とちゅう",
       "Kanji": "途中",
       "Definition": "on the way, en route, midway"
     },
     {
+      "ID": "N4#472",
       "Kana": "とっきゅう",
       "Kanji": "特急",
       "Definition": "limited express (train, faster than an express)"
     },
     {
+      "ID": "N4#473",
       "Kana": "とどける",
       "Kanji": "届ける",
       "Definition": "to reach"
     },
     {
+      "ID": "N4#474",
       "Kana": "とまる",
       "Kanji": "泊まる",
       "Definition": "to stay at (eg. hotel)"
     },
     {
+      "ID": "N4#475",
       "Kana": "とめる",
       "Kanji": "止める",
       "Definition": "to stop (something)"
     },
     {
+      "ID": "N4#476",
       "Kana": "とりかえる",
       "Kanji": "取り替える",
       "Definition": "to exchange, to replace"
@@ -2443,21 +2919,25 @@
   ],
   "ど": [
     {
+      "ID": "N4#477",
       "Kana": "どうぐ",
       "Kanji": "道具",
       "Definition": "tool, means"
     },
     {
+      "ID": "N4#478",
       "Kana": "どうぶつえん",
       "Kanji": "動物園",
       "Definition": "zoo"
     },
     {
+      "ID": "N4#479",
       "Kana": "どろぼう",
       "Kanji": "泥棒",
       "Definition": "thief, burglar, robber"
     },
     {
+      "ID": "N4#480",
       "Kana": "どんどん",
       "Kanji": "",
       "Definition": "steadily, little by little"
@@ -2465,66 +2945,79 @@
   ],
   "な": [
     {
+      "ID": "N4#481",
       "Kana": "なおす",
       "Kanji": "直す",
       "Definition": "to fix, to repair"
     },
     {
+      "ID": "N4#482",
       "Kana": "なおる",
       "Kanji": "直る",
       "Definition": "to be fixed, to be repaired"
     },
     {
+      "ID": "N4#483",
       "Kana": "なおる",
       "Kanji": "治る",
       "Definition": "to be cured, to heal"
     },
     {
+      "ID": "N4#484",
       "Kana": "なかなか",
       "Kanji": "中々",
       "Definition": "very, considerably, quite"
     },
     {
+      "ID": "N4#485",
       "Kana": "なく",
       "Kanji": "泣く",
       "Definition": "to cry, to weep"
     },
     {
+      "ID": "N4#486",
       "Kana": "なくなる",
       "Kanji": "無くなる",
       "Definition": "to disappear, to get lost"
     },
     {
+      "ID": "N4#487",
       "Kana": "なくなる",
       "Kanji": "亡くなる",
       "Definition": "to die"
     },
     {
+      "ID": "N4#488",
       "Kana": "なげる",
       "Kanji": "投げる",
       "Definition": "to throw, to cast away"
     },
     {
+      "ID": "N4#489",
       "Kana": "なさる",
       "Kanji": "",
       "Definition": "(hon) to do"
     },
     {
+      "ID": "N4#490",
       "Kana": "なる",
       "Kanji": "鳴る",
       "Definition": "to sound, to ring, to resound"
     },
     {
+      "ID": "N4#491",
       "Kana": "なるべく",
       "Kanji": "",
       "Definition": "as much as possible"
     },
     {
+      "ID": "N4#492",
       "Kana": "なるほど",
       "Kanji": "",
       "Definition": "I see, now I understand"
     },
     {
+      "ID": "N4#493",
       "Kana": "なれる",
       "Kanji": "慣れる",
       "Definition": "to grow accustomed to"
@@ -2532,51 +3025,61 @@
   ],
   "に": [
     {
+      "ID": "N4#494",
       "Kana": "におい",
       "Kanji": "",
       "Definition": "odour, scent, smell"
     },
     {
+      "ID": "N4#495",
       "Kana": "にがい",
       "Kanji": "苦い",
       "Definition": "bitter"
     },
     {
+      "ID": "N4#496",
       "Kana": "にげる",
       "Kanji": "逃げる",
       "Definition": "to escape, to run away"
     },
     {
+      "ID": "N4#497",
       "Kana": "にっき",
       "Kanji": "日記",
       "Definition": "diary, journal"
     },
     {
+      "ID": "N4#498",
       "Kana": "にゅういん",
       "Kanji": "入院",
       "Definition": "hospitalization"
     },
     {
+      "ID": "N4#499",
       "Kana": "にゅういんする",
       "Kanji": "入院する",
       "Definition": "to be hospitalized"
     },
     {
+      "ID": "N4#500",
       "Kana": "にゅうがく",
       "Kanji": "入学",
       "Definition": "entry to school or university, matriculation"
     },
     {
+      "ID": "N4#501",
       "Kana": "にゅうがくする",
       "Kanji": "入学する",
       "Definition": "to enter a school or university"
     },
     {
+      "ID": "N4#502",
       "Kana": "にる",
       "Kanji": "似る",
       "Definition": "to resemble, to be similar"
     },
     {
+      "ID": "N4#503",
       "Kana": "にんぎょう",
       "Kanji": "人形",
       "Definition": "doll, puppet, figure"
@@ -2584,16 +3087,19 @@
   ],
   "ぬ": [
     {
+      "ID": "N4#504",
       "Kana": "ぬすむ",
       "Kanji": "盗む",
       "Definition": "to steal"
     },
     {
+      "ID": "N4#505",
       "Kana": "ぬる",
       "Kanji": "塗る",
       "Definition": "to paint, to plaster"
     },
     {
+      "ID": "N4#506",
       "Kana": "ぬれる",
       "Kanji": "",
       "Definition": "to get wet"
@@ -2601,31 +3107,37 @@
   ],
   "ね": [
     {
+      "ID": "N4#507",
       "Kana": "ねだん",
       "Kanji": "",
       "Definition": "price, cost"
     },
     {
+      "ID": "N4#508",
       "Kana": "ねつ",
       "Kanji": "熱",
       "Definition": "fever, temperature"
     },
     {
+      "ID": "N4#509",
       "Kana": "ねっしん",
-      "Kanji": "",
+      "Kanji": "熱心",
       "Definition": "zeal, enthusiasm"
     },
     {
+      "ID": "N4#510",
       "Kana": "ねぼう",
       "Kanji": "寝坊",
       "Definition": "sleeping in late"
     },
     {
+      "ID": "N4#511",
       "Kana": "ねむい",
       "Kanji": "眠い",
       "Definition": "sleepy, drowsy"
     },
     {
+      "ID": "N4#512",
       "Kana": "ねむる",
       "Kanji": "眠る",
       "Definition": "to sleep"
@@ -2633,21 +3145,25 @@
   ],
   "の": [
     {
+      "ID": "N4#513",
       "Kana": "のこる",
       "Kanji": "残る",
       "Definition": "to remain, to be left"
     },
     {
+      "ID": "N4#514",
       "Kana": "のど",
       "Kanji": "",
       "Definition": "throat"
     },
     {
+      "ID": "N4#515",
       "Kana": "のりかえる",
       "Kanji": "乗り換える",
       "Definition": "to transfer (trains), to change (bus, train)"
     },
     {
+      "ID": "N4#516",
       "Kana": "のりもの",
       "Kanji": "乗り物",
       "Definition": "vehicle"
@@ -2655,76 +3171,91 @@
   ],
   "は": [
     {
+      "ID": "N4#517",
       "Kana": "は",
       "Kanji": "葉",
       "Definition": "leaf"
     },
     {
+      "ID": "N4#518",
       "Kana": "はいけん",
       "Kanji": "拝見",
       "Definition": "seeing, look at (humble) (polite)"
     },
     {
+      "ID": "N4#519",
       "Kana": "はいけんする",
       "Kanji": "拝見する",
       "Definition": "to see, to look at (humble) (polite)"
     },
     {
+      "ID": "N4#520",
       "Kana": "はいしゃ",
       "Kanji": "歯医者",
       "Definition": "dentist"
     },
     {
+      "ID": "N4#521",
       "Kana": "はこぶ",
       "Kanji": "運ぶ",
       "Definition": "to transport, to carry"
     },
     {
+      "ID": "N4#522",
       "Kana": "はじめる",
       "Kanji": "始める",
       "Definition": "to start, to begin"
     },
     {
+      "ID": "N4#523",
       "Kana": "はず",
       "Kanji": "",
       "Definition": "it should be so"
     },
     {
+      "ID": "N4#524",
       "Kana": "はずかしい",
       "Kanji": "恥ずかしい",
       "Definition": "shy, ashamed, embarrassed"
     },
     {
+      "ID": "N4#525",
       "Kana": "はつおん",
       "Kanji": "発音",
       "Definition": "pronunciation"
     },
     {
+      "ID": "N4#526",
       "Kana": "はっきり",
       "Kanji": "",
       "Definition": "clearly, plainly, distinctly"
     },
     {
+      "ID": "N4#527",
       "Kana": "はなみ",
       "Kanji": "花見",
       "Definition": "cherry-blossom viewing, flower viewing"
     },
     {
+      "ID": "N4#528",
       "Kana": "はやし",
       "Kanji": "林",
       "Definition": "woods, forester"
     },
     {
+      "ID": "N4#529",
       "Kana": "はらう",
       "Kanji": "払う",
       "Definition": "to pay"
     },
     {
+      "ID": "N4#530",
       "Kana": "はんたい",
       "Kanji": "反対",
       "Definition": "oppose, opposition, resistance"
     },
     {
+      "ID": "N4#531",
       "Kana": "ハンバーグ",
       "Kanji": "",
       "Definition": "hamburger (meat, no bun)"
@@ -2732,21 +3263,25 @@
   ],
   "ば": [
     {
+      "ID": "N4#532",
       "Kana": "ばあい",
       "Kanji": "場合",
       "Definition": "case, situation"
     },
     {
+      "ID": "N4#533",
       "Kana": "ばい",
       "Kanji": "倍",
       "Definition": "twice, double"
     },
     {
+      "ID": "N4#534",
       "Kana": "ばしょ",
       "Kanji": "場所",
       "Definition": "place, location"
     },
     {
+      "ID": "N4#535",
       "Kana": "ばんぐみ",
       "Kanji": "番組",
       "Definition": "program (eg. TV)"
@@ -2754,16 +3289,19 @@
   ],
   "ぱ": [
     {
+      "ID": "N4#536",
       "Kana": "パート",
       "Kanji": "",
       "Definition": "part time (esp female part time employees)"
     },
     {
+      "ID": "N4#537",
       "Kana": "パソコン",
       "Kanji": "",
       "Definition": "(personal) computer"
     },
     {
+      "ID": "N4#538",
       "Kana": "パパ",
       "Kanji": "",
       "Definition": "papa, father"
@@ -2771,86 +3309,103 @@
   ],
   "ひ": [
     {
+      "ID": "N4#539",
       "Kana": "ひ",
       "Kanji": "日",
       "Definition": "sun, sunshine, day"
     },
     {
+      "ID": "N4#540",
       "Kana": "ひ",
       "Kanji": "火",
       "Definition": "fire, flame, blaze"
     },
     {
+      "ID": "N4#541",
       "Kana": "ひえる",
       "Kanji": "冷える",
       "Definition": "to grow cold, to get chilly, to cool down"
     },
     {
+      "ID": "N4#542",
       "Kana": "ひかる",
       "Kanji": "光る",
       "Definition": "to shine, to glitter"
     },
     {
+      "ID": "N4#543",
       "Kana": "ひかり",
       "Kanji": "光",
       "Definition": "light"
     },
     {
+      "ID": "N4#544",
       "Kana": "ひきだし",
       "Kanji": "引き出し",
       "Definition": "drawer, drawing out"
     },
     {
+      "ID": "N4#545",
       "Kana": "ひげ",
       "Kanji": "",
       "Definition": "beard"
     },
     {
+      "ID": "N4#546",
       "Kana": "ひこうじょう",
       "Kanji": "飛行場",
       "Definition": "airport"
     },
     {
+      "ID": "N4#547",
       "Kana": "ひさしぶり",
       "Kanji": "久しぶり",
       "Definition": "after a long time"
     },
     {
+      "ID": "N4#548",
       "Kana": "ひじょうに",
       "Kanji": "非常に",
       "Definition": "very, extremely, exceedingly"
     },
     {
+      "ID": "N4#549",
       "Kana": "ひっこす",
       "Kanji": "引っ越す",
       "Definition": "to move, to change residence"
     },
     {
+      "ID": "N4#550",
       "Kana": "ひつよう",
       "Kanji": "必要",
       "Definition": "necessary, essential"
     },
     {
+      "ID": "N4#551",
       "Kana": "ひどい",
       "Kanji": "",
       "Definition": "cruel, awful"
     },
     {
+      "ID": "N4#552",
       "Kana": "ひらく",
       "Kanji": "開く",
       "Definition": "to open (eg. a festival)"
     },
     {
+      "ID": "N4#553",
       "Kana": "ひるま",
       "Kanji": "昼間",
       "Definition": "daytime, during the day"
     },
     {
+      "ID": "N4#554",
       "Kana": "ひるやすみ",
       "Kanji": "昼休み",
       "Definition": "lunch break, noon recess, noon rest period"
     },
     {
+      "ID": "N4#555",
       "Kana": "ひろう",
       "Kanji": "拾う",
       "Definition": "to pick up, to find, to gather"
@@ -2858,16 +3413,19 @@
   ],
   "び": [
     {
+      "ID": "N4#556",
       "Kana": "びじゅつかん",
       "Kanji": "美術館",
       "Definition": "art gallery, art museum"
     },
     {
+      "ID": "N4#557",
       "Kana": "びっくりする",
       "Kanji": "",
       "Definition": "to be surprised"
     },
     {
+      "ID": "N4#558",
       "Kana": "ビル",
       "Kanji": "",
       "Definition": "(abbr) building, bill"
@@ -2875,6 +3433,7 @@
   ],
   "ぴ": [
     {
+      "ID": "N4#559",
       "Kana": "ピアノ",
       "Kanji": "",
       "Definition": "piano"
@@ -2882,56 +3441,67 @@
   ],
   "ふ": [
     {
+      "ID": "N4#560",
       "Kana": "ファックス",
       "Kanji": "",
       "Definition": "fax"
     },
     {
+      "ID": "N4#561",
       "Kana": "ふえる",
       "Kanji": "増える",
       "Definition": "to increase, to multiply"
     },
     {
+      "ID": "N4#562",
       "Kana": "ふかい",
       "Kanji": "深い",
       "Definition": "deep, profound, thick"
     },
     {
+      "ID": "N4#563",
       "Kana": "ふくざつ",
       "Kanji": "複雑",
       "Definition": "complexity, complication"
     },
     {
+      "ID": "N4#564",
       "Kana": "ふくしゅう",
       "Kanji": "復習",
       "Definition": "review, revision"
     },
     {
+      "ID": "N4#565",
       "Kana": "ふつう",
       "Kanji": "普通",
       "Definition": "(1) generally, ordinarily, usually, (2) train that stops at every station"
     },
     {
+      "ID": "N4#566",
       "Kana": "ふとる",
       "Kanji": "太る",
       "Definition": "to grow fat (stout, plump), to become fat"
     },
     {
+      "ID": "N4#567",
       "Kana": "ふとん",
       "Kanji": "布団",
       "Definition": "bedding (Japanese style), futon"
     },
     {
+      "ID": "N4#568",
       "Kana": "ふね",
       "Kanji": "舟",
       "Definition": "ship, boat"
     },
     {
+      "ID": "N4#569",
       "Kana": "ふべん",
       "Kanji": "不便",
       "Definition": "inconvenience"
     },
     {
+      "ID": "N4#570",
       "Kana": "ふむ",
       "Kanji": "踏む",
       "Definition": "to step on, to tread on"
@@ -2939,26 +3509,31 @@
   ],
   "ぶ": [
     {
+      "ID": "N4#571",
       "Kana": "ぶちょう",
       "Kanji": "部長",
       "Definition": "head of a section"
     },
     {
+      "ID": "N4#572",
       "Kana": "ぶどう",
       "Kanji": "",
       "Definition": "grapes"
     },
     {
+      "ID": "N4#573",
       "Kana": "ぶんか",
       "Kanji": "文化",
       "Definition": "culture, civilization"
     },
     {
+      "ID": "N4#574",
       "Kana": "ぶんがく",
       "Kanji": "文学",
       "Definition": "literature"
     },
     {
+      "ID": "N4#575",
       "Kana": "ぶんぽう",
       "Kanji": "文法",
       "Definition": "grammar"
@@ -2966,6 +3541,7 @@
   ],
   "ぷ": [
     {
+      "ID": "N4#576",
       "Kana": "プレゼント",
       "Kanji": "",
       "Definition": "present, gift"
@@ -2973,11 +3549,13 @@
   ],
   "へ": [
     {
+      "ID": "N4#577",
       "Kana": "へん",
       "Kanji": "変",
       "Definition": "strange, odd, peculiar"
     },
     {
+      "ID": "N4#578",
       "Kana": "へんじ",
       "Kanji": "返事",
       "Definition": "reply, answer"
@@ -2985,11 +3563,13 @@
   ],
   "べ": [
     {
+      "ID": "N4#579",
       "Kana": "べつ",
       "Kanji": "別",
       "Definition": "distinction, different"
     },
     {
+      "ID": "N4#580",
       "Kana": "ベル",
       "Kanji": "",
       "Definition": "bell"
@@ -2997,41 +3577,49 @@
   ],
   "ほ": [
     {
+      "ID": "N4#581",
       "Kana": "ほうそう",
       "Kanji": "放送",
       "Definition": "broadcast, broadcasting"
     },
     {
+      "ID": "N4#582",
       "Kana": "ほうそうする",
       "Kanji": "放送する",
       "Definition": "to broadcast"
     },
     {
+      "ID": "N4#583",
       "Kana": "ほうりつ",
       "Kanji": "法律",
       "Definition": "law"
     },
     {
+      "ID": "N4#584",
       "Kana": "ほし",
       "Kanji": "星",
       "Definition": "star"
     },
     {
+      "ID": "N4#585",
       "Kana": "ほど",
       "Kanji": "",
       "Definition": "degree, extent"
     },
     {
+      "ID": "N4#586",
       "Kana": "ほとんど",
       "Kanji": "",
       "Definition": "mostly, almost"
     },
     {
+      "ID": "N4#587",
       "Kana": "ほめる",
       "Kanji": "",
       "Definition": "to praise"
     },
     {
+      "ID": "N4#588",
       "Kana": "ほんやく",
       "Kanji": "翻訳",
       "Definition": "translation (written)"
@@ -3039,11 +3627,13 @@
   ],
   "ぼ": [
     {
+      "ID": "N4#589",
       "Kana": "ぼうえき",
       "Kanji": "貿易",
       "Definition": "trade (foreign)"
     },
     {
+      "ID": "N4#590",
       "Kana": "ぼく",
       "Kanji": "僕",
       "Definition": "(male) I, manservant"
@@ -3051,56 +3641,67 @@
   ],
   "ま": [
     {
+      "ID": "N4#591",
       "Kana": "まいる",
       "Kanji": "参る",
       "Definition": "(1) (hum) to go, to come"
     },
     {
+      "ID": "N4#592",
       "Kana": "まける",
       "Kanji": "負ける",
       "Definition": "to lose, to be defeated"
     },
     {
+      "ID": "N4#593",
       "Kana": "まじめ",
-      "Kanji": "",
+      "Kanji": "真面目",
       "Definition": "diligent, serious"
     },
     {
+      "ID": "N4#594",
       "Kana": "まず",
       "Kanji": "",
       "Definition": "first (of all), to start with"
     },
     {
+      "ID": "N4#595",
       "Kana": "または",
       "Kanji": "",
       "Definition": "or, otherwise"
     },
     {
+      "ID": "N4#596",
       "Kana": "まちがえる",
       "Kanji": "間違える",
       "Definition": "to err, to make a mistake"
     },
     {
+      "ID": "N4#597",
       "Kana": "まにあう",
       "Kanji": "間に合う",
       "Definition": "(1) to be in time for"
     },
     {
+      "ID": "N4#598",
       "Kana": "まわり",
       "Kanji": "周り",
       "Definition": "surroundings, circulation"
     },
     {
+      "ID": "N4#599",
       "Kana": "まわる",
       "Kanji": "回る",
       "Definition": "to go around, to revolve"
     },
     {
+      "ID": "N4#600",
       "Kana": "まんが",
       "Kanji": "漫画",
       "Definition": "comic, cartoon"
     },
     {
+      "ID": "N4#601",
       "Kana": "まんなか",
       "Kanji": "真中",
       "Definition": "middle, centre"
@@ -3108,36 +3709,43 @@
   ],
   "み": [
     {
+      "ID": "N4#602",
       "Kana": "みえる",
       "Kanji": "見える",
       "Definition": "to be seen, to be in sight"
     },
     {
+      "ID": "N4#603",
       "Kana": "みずうみ",
       "Kanji": "湖",
       "Definition": "lake"
     },
     {
+      "ID": "N4#604",
       "Kana": "みそ",
       "Kanji": "味噌",
       "Definition": "miso, bean paste"
     },
     {
+      "ID": "N4#605",
       "Kana": "みつかる",
       "Kanji": "見つかる",
       "Definition": "(uk) to be found, to be discovered"
     },
     {
+      "ID": "N4#606",
       "Kana": "みつける",
       "Kanji": "見つける",
       "Definition": "to discover, to find"
     },
     {
+      "ID": "N4#607",
       "Kana": "みな",
       "Kanji": "皆",
       "Definition": "everyone, everybody"
     },
     {
+      "ID": "N4#608",
       "Kana": "みなと",
       "Kanji": "港",
       "Definition": "harbour, port"
@@ -3145,36 +3753,43 @@
   ],
   "む": [
     {
+      "ID": "N4#609",
       "Kana": "むかえる",
       "Kanji": "迎える",
       "Definition": "to go out to meet"
     },
     {
+      "ID": "N4#610",
       "Kana": "むかう",
       "Kanji": "向かう",
       "Definition": "to face, to go towards"
     },
     {
+      "ID": "N4#611",
       "Kana": "むかし",
       "Kanji": "昔",
       "Definition": "olden days, former"
     },
     {
+      "ID": "N4#612",
       "Kana": "むし",
       "Kanji": "虫",
       "Definition": "insect"
     },
     {
+      "ID": "N4#613",
       "Kana": "むすこ",
       "Kanji": "息子",
       "Definition": "(hum) son"
     },
     {
+      "ID": "N4#614",
       "Kana": "むすめ",
       "Kanji": "娘",
       "Definition": "(hum) daughter"
     },
     {
+      "ID": "N4#615",
       "Kana": "むり",
       "Kanji": "無理",
       "Definition": "unreasonable, impossible"
@@ -3182,11 +3797,13 @@
   ],
   "め": [
     {
+      "ID": "N4#616",
       "Kana": "めしあがる",
       "Kanji": "召し上がる",
       "Definition": "(pol) to eat"
     },
     {
+      "ID": "N4#617",
       "Kana": "めずらしい",
       "Kanji": "珍しい",
       "Definition": "unusual, rare"
@@ -3194,51 +3811,61 @@
   ],
   "も": [
     {
+      "ID": "N4#618",
       "Kana": "もうしあげる",
       "Kanji": "申し上げる",
       "Definition": "to say, to tell"
     },
     {
+      "ID": "N4#619",
       "Kana": "もうす",
       "Kanji": "申す",
       "Definition": "(hum) to be called, to say"
     },
     {
+      "ID": "N4#620",
       "Kana": "もうすぐ",
       "Kanji": "",
       "Definition": "soon, very soon"
     },
     {
+      "ID": "N4#621",
       "Kana": "もし",
       "Kanji": "",
       "Definition": "if"
     },
     {
+      "ID": "N4#622",
       "Kana": "もちろん",
       "Kanji": "",
       "Definition": "certainly, of course"
     },
     {
+      "ID": "N4#623",
       "Kana": "もっとも",
       "Kanji": "",
       "Definition": "most, extremely"
     },
     {
+      "ID": "N4#624",
       "Kana": "もどる",
       "Kanji": "戻る",
       "Definition": "to turn back, to return"
     },
     {
+      "ID": "N4#625",
       "Kana": "もめん",
       "Kanji": "木綿",
       "Definition": "cotton"
     },
     {
+      "ID": "N4#626",
       "Kana": "もらう",
       "Kanji": "",
       "Definition": "to receive"
     },
     {
+      "ID": "N4#627",
       "Kana": "もり",
       "Kanji": "森",
       "Definition": "forest"
@@ -3246,61 +3873,73 @@
   ],
   "や": [
     {
+      "ID": "N4#628",
       "Kana": "やく",
       "Kanji": "焼く",
       "Definition": "to bake, to grill"
     },
     {
+      "ID": "N4#629",
       "Kana": "やくにたつ",
       "Kanji": "役に立つ",
       "Definition": "to be helpful, to be useful"
     },
     {
+      "ID": "N4#630",
       "Kana": "やくそく",
       "Kanji": "約束",
       "Definition": "arrangement, promise"
     },
     {
+      "ID": "N4#631",
       "Kana": "やける",
       "Kanji": "焼ける",
       "Definition": "to burn, to be roasted, to be sunburnt"
     },
     {
+      "ID": "N4#632",
       "Kana": "やさしい",
       "Kanji": "優しい",
       "Definition": "kind, gentle"
     },
     {
+      "ID": "N4#633",
       "Kana": "やせる",
       "Kanji": "",
       "Definition": "to become thin, to lose weight"
     },
     {
+      "ID": "N4#634",
       "Kana": "やっと",
       "Kanji": "",
       "Definition": "at last, at length"
     },
     {
+      "ID": "N4#635",
       "Kana": "やはり",
       "Kanji": "",
       "Definition": "as I thought, absolutely"
     },
     {
+      "ID": "N4#636",
       "Kana": "やっぱり",
       "Kanji": "",
       "Definition": "as I thought, absolutely"
     },
     {
+      "ID": "N4#637",
       "Kana": "やむ",
       "Kanji": "",
       "Definition": "to cease, to stop"
     },
     {
+      "ID": "N4#638",
       "Kana": "やめる",
       "Kanji": "止める",
       "Definition": "to end, to stop, to resign"
     },
     {
+      "ID": "N4#639",
       "Kana": "やわらかい",
       "Kanji": "柔らかい",
       "Definition": "soft, tender"
@@ -3308,46 +3947,55 @@
   ],
   "ゆ": [
     {
+      "ID": "N4#640",
       "Kana": "ゆ",
       "Kanji": "湯",
       "Definition": "hot water"
     },
     {
+      "ID": "N4#641",
       "Kana": "ゆしゅつ",
       "Kanji": "輸出",
       "Definition": "export"
     },
     {
+      "ID": "N4#642",
       "Kana": "ゆしゅつする",
       "Kanji": "輸出する",
       "Definition": "to export"
     },
     {
+      "ID": "N4#643",
       "Kana": "ゆにゅう",
       "Kanji": "輸入",
       "Definition": "import"
     },
     {
+      "ID": "N4#644",
       "Kana": "ゆにゅうする",
       "Kanji": "輸入する",
       "Definition": "to import"
     },
     {
+      "ID": "N4#645",
       "Kana": "ゆび",
       "Kanji": "指",
       "Definition": "finger"
     },
     {
+      "ID": "N4#646",
       "Kana": "ゆびわ",
       "Kanji": "指輪",
       "Definition": "(finger) ring"
     },
     {
+      "ID": "N4#647",
       "Kana": "ゆめ",
       "Kanji": "夢",
       "Definition": "dream"
     },
     {
+      "ID": "N4#648",
       "Kana": "ゆれる",
       "Kanji": "揺れる",
       "Definition": "to shake, to sway"
@@ -3355,56 +4003,67 @@
   ],
   "よ": [
     {
+      "ID": "N4#649",
       "Kana": "よう",
       "Kanji": "様",
       "Definition": "way, manner, kind"
     },
     {
+      "ID": "N4#650",
       "Kana": "よう",
       "Kanji": "用",
       "Definition": "task, business, use"
     },
     {
+      "ID": "N4#651",
       "Kana": "ようい",
       "Kanji": "用意",
       "Definition": "preparation"
     },
     {
+      "ID": "N4#652",
       "Kana": "ようじ",
       "Kanji": "用事",
       "Definition": "tasks, chores"
     },
     {
+      "ID": "N4#653",
       "Kana": "よごれる",
       "Kanji": "汚れる",
       "Definition": "to get dirty, to become dirty"
     },
     {
+      "ID": "N4#654",
       "Kana": "よしゅう",
       "Kanji": "予習",
       "Definition": "preparation for a lesson"
     },
     {
+      "ID": "N4#655",
       "Kana": "よてい",
       "Kanji": "予定",
       "Definition": "plans, arrangement, schedule"
     },
     {
+      "ID": "N4#656",
       "Kana": "よやく",
       "Kanji": "予約",
       "Definition": "reservation, booking"
     },
     {
+      "ID": "N4#657",
       "Kana": "よる",
       "Kanji": "寄る",
       "Definition": "to visit, to drop in"
     },
     {
+      "ID": "N4#658",
       "Kana": "よろこぶ",
       "Kanji": "喜ぶ",
       "Definition": "to be delighted, to be glad"
     },
     {
+      "ID": "N4#659",
       "Kana": "よろしい",
       "Kanji": "",
       "Definition": "(hon) good, OK, all right"
@@ -3412,26 +4071,31 @@
   ],
   "り": [
     {
+      "ID": "N4#660",
       "Kana": "リポート",
       "Kanji": "",
       "Definition": "report, essay, assignment (aus)"
     },
     {
+      "ID": "N4#661",
       "Kana": "りゆう",
       "Kanji": "理由",
       "Definition": "reason, pretext, motive"
     },
     {
+      "ID": "N4#662",
       "Kana": "りよう",
       "Kanji": "利用",
       "Definition": "use, utilization"
     },
     {
+      "ID": "N4#663",
       "Kana": "りょうほう",
       "Kanji": "両方",
       "Definition": "both sides, both parties"
     },
     {
+      "ID": "N4#664",
       "Kana": "りょかん",
       "Kanji": "旅館",
       "Definition": "Japanese hotel, inn"
@@ -3439,6 +4103,7 @@
   ],
   "る": [
     {
+      "ID": "N4#665",
       "Kana": "るす",
       "Kanji": "留守",
       "Definition": "absence, being away from home"
@@ -3446,26 +4111,31 @@
   ],
   "れ": [
     {
+      "ID": "N4#666",
       "Kana": "れいぼう",
       "Kanji": "冷房",
       "Definition": "cooling, air conditioning"
     },
     {
+      "ID": "N4#667",
       "Kana": "れきし",
       "Kanji": "歴史",
       "Definition": "history"
     },
     {
+      "ID": "N4#668",
       "Kana": "レジ",
       "Kanji": "",
       "Definition": "register"
     },
     {
+      "ID": "N4#669",
       "Kana": "レポート",
       "Kanji": "",
       "Definition": "report, essay, assignment (aus)"
     },
     {
+      "ID": "N4#670",
       "Kana": "れんらく",
       "Kanji": "連絡",
       "Definition": "communication, contact, connection"
@@ -3473,46 +4143,55 @@
   ],
   "わ": [
     {
+      "ID": "N4#671",
       "Kana": "ワープロ",
       "Kanji": "",
       "Definition": "word processor"
     },
     {
+      "ID": "N4#672",
       "Kana": "わかす",
       "Kanji": "沸かす",
       "Definition": "to boil, to heat"
     },
     {
+      "ID": "N4#673",
       "Kana": "わかれる",
       "Kanji": "別れる",
       "Definition": "to be divided, to part from, to separate"
     },
     {
+      "ID": "N4#674",
       "Kana": "わく",
       "Kanji": "沸く",
       "Definition": "to boil, to grow hot, to get excited"
     },
     {
+      "ID": "N4#675",
       "Kana": "わけ",
       "Kanji": "訳",
       "Definition": "meaning, reason"
     },
     {
+      "ID": "N4#676",
       "Kana": "わすれもの",
       "Kanji": "忘れ物",
       "Definition": "lost article, something forgotten"
     },
     {
+      "ID": "N4#677",
       "Kana": "わらう",
       "Kanji": "笑う",
       "Definition": "to laugh, to smile"
     },
     {
+      "ID": "N4#678",
       "Kana": "わりあい",
       "Kanji": "割合",
       "Definition": "rate, ratio, percentage"
     },
     {
+      "ID": "N4#679",
       "Kana": "われる",
       "Kanji": "割れる",
       "Definition": "to break"

--- a/vocab-n5.json
+++ b/vocab-n5.json
@@ -1,216 +1,259 @@
 {
   "あ": [
     {
+      "ID": "N5#1",
       "Kana": "ああ",
       "Kanji": "",
       "Definition": "Ah!, Oh!"
     },
     {
+      "ID": "N5#2",
       "Kana": "あう",
       "Kanji": "会う",
       "Definition": "to meet, to see"
     },
     {
+      "ID": "N5#3",
       "Kana": "あお",
       "Kanji": "青",
       "Definition": "blue"
     },
     {
+      "ID": "N5#4",
       "Kana": "あおい",
       "Kanji": "青い",
       "Definition": "blue"
     },
     {
+      "ID": "N5#5",
       "Kana": "あか",
       "Kanji": "赤",
       "Definition": "red"
     },
     {
+      "ID": "N5#6",
       "Kana": "あかい",
       "Kanji": "赤い",
       "Definition": "red"
     },
     {
+      "ID": "N5#7",
       "Kana": "あかるい",
       "Kanji": "明るい",
       "Definition": "bright, cheerful"
     },
     {
+      "ID": "N5#8",
       "Kana": "あき",
       "Kanji": "秋",
       "Definition": "autumn, fall"
     },
     {
+      "ID": "N5#9",
       "Kana": "あく",
       "Kanji": "開く",
       "Definition": "to open, to become open"
     },
     {
+      "ID": "N5#10",
       "Kana": "あける",
       "Kanji": "開ける",
       "Definition": "to open"
     },
     {
+      "ID": "N5#11",
       "Kana": "あげる",
       "Kanji": "上げる",
       "Definition": "to give"
     },
     {
+      "ID": "N5#12",
       "Kana": "あさ",
       "Kanji": "朝",
       "Definition": "morning"
     },
     {
+      "ID": "N5#13",
       "Kana": "あさごはん",
       "Kanji": "朝御飯",
       "Definition": "breakfast"
     },
     {
+      "ID": "N5#14",
       "Kana": "あさって",
       "Kanji": "",
       "Definition": "day after tomorrow"
     },
     {
+      "ID": "N5#15",
       "Kana": "あし",
       "Kanji": "足",
       "Definition": "foot, leg"
     },
     {
+      "ID": "N5#16",
       "Kana": "あした",
       "Kanji": "",
       "Definition": "tomorrow"
     },
     {
+      "ID": "N5#17",
       "Kana": "あそこ",
       "Kanji": "",
       "Definition": "there, over there, that place"
     },
     {
+      "ID": "N5#18",
       "Kana": "あそぶ",
       "Kanji": "遊ぶ",
       "Definition": "to play, to enjoy oneself"
     },
     {
+      "ID": "N5#19",
       "Kana": "あたたかい",
       "Kanji": "暖かい",
       "Definition": "warm, mild"
     },
     {
+      "ID": "N5#20",
       "Kana": "あたま",
       "Kanji": "頭",
       "Definition": "head"
     },
     {
+      "ID": "N5#21",
       "Kana": "あたらしい",
       "Kanji": "新しい",
       "Definition": "new"
     },
     {
+      "ID": "N5#22",
       "Kana": "あちら",
       "Kanji": "",
       "Definition": "there, yonder, that"
     },
     {
+      "ID": "N5#23",
       "Kana": "あつい",
       "Kanji": "暑い",
       "Definition": "hot, warm"
     },
     {
+      "ID": "N5#24",
       "Kana": "あつい",
       "Kanji": "熱い",
       "Definition": "hot (thing)"
     },
     {
+      "ID": "N5#25",
       "Kana": "あつい",
       "Kanji": "厚い",
       "Definition": "kind, warm(hearted), thick, deep"
     },
     {
+      "ID": "N5#26",
       "Kana": "あっち",
       "Kanji": "",
       "Definition": "over there"
     },
     {
+      "ID": "N5#27",
       "Kana": "あと",
       "Kanji": "後",
       "Definition": "afterwards, since then, in the future"
     },
     {
+      "ID": "N5#28",
       "Kana": "あなた",
       "Kanji": "",
       "Definition": "you"
     },
     {
+      "ID": "N5#29",
       "Kana": "あに",
       "Kanji": "兄",
       "Definition": "(hum) older brother"
     },
     {
+      "ID": "N5#30",
       "Kana": "あね",
       "Kanji": "姉",
       "Definition": "(hum) older sister"
     },
     {
+      "ID": "N5#31",
       "Kana": "あの",
       "Kanji": "",
       "Definition": "that over there"
     },
     {
+      "ID": "N5#32",
       "Kana": "あの",
       "Kanji": "",
       "Definition": "um..."
     },
     {
+      "ID": "N5#33",
       "Kana": "アパート",
       "Kanji": "",
       "Definition": "apartment (abbr)"
     },
     {
+      "ID": "N5#34",
       "Kana": "あびる",
       "Kanji": "",
       "Definition": "to bathe, to shower"
     },
     {
+      "ID": "N5#35",
       "Kana": "あぶない",
       "Kanji": "危ない",
       "Definition": "dangerous, critical, watch out!"
     },
     {
+      "ID": "N5#36",
       "Kana": "あまい",
       "Kanji": "甘い",
       "Definition": "generous, sweet"
     },
     {
+      "ID": "N5#37",
       "Kana": "あまり",
       "Kanji": "",
       "Definition": "not very, not much"
     },
     {
+      "ID": "N5#38",
       "Kana": "あめ",
       "Kanji": "雨",
       "Definition": "rain"
     },
     {
+      "ID": "N5#39",
       "Kana": "あめ",
       "Kanji": "飴",
       "Definition": "(hard) candy, toffee"
     },
     {
+      "ID": "N5#40",
       "Kana": "あらう",
       "Kanji": "洗う",
       "Definition": "to wash"
     },
     {
+      "ID": "N5#41",
       "Kana": "ある",
       "Kanji": "",
       "Definition": "to be [存在], to have [所有]"
     },
     {
+      "ID": "N5#42",
       "Kana": "あるく",
       "Kanji": "歩く",
       "Definition": "to walk"
     },
     {
+      "ID": "N5#43",
       "Kana": "あれ",
       "Kanji": "",
       "Definition": "that, that thing"
@@ -218,161 +261,193 @@
   ],
   "い": [
     {
+      "ID": "N5#44",
       "Kana": "いい",
       "Kanji": "",
       "Definition": "good"
     },
     {
+      "ID": "N5#45",
       "Kana": "いいえ",
       "Kanji": "",
       "Definition": "no, not at all"
     },
     {
+      "ID": "N5#46",
       "Kana": "いう",
       "Kanji": "言う",
       "Definition": "to say"
     },
     {
+      "ID": "N5#47",
       "Kana": "いえ",
       "Kanji": "家",
       "Definition": "house, family"
     },
     {
+      "ID": "N5#48",
       "Kana": "いかが",
       "Kanji": "",
       "Definition": "how, in what way"
     },
     {
+      "ID": "N5#49",
       "Kana": "いく",
       "Kanji": "行く",
       "Definition": "to go"
     },
     {
+      "ID": "N5#50",
       "Kana": "いくつ",
       "Kanji": "",
       "Definition": "how many?, how old?"
     },
     {
+      "ID": "N5#51",
       "Kana": "いくら",
       "Kanji": "",
       "Definition": "how much?, how many?"
     },
     {
+      "ID": "N5#52",
       "Kana": "いけ",
       "Kanji": "池",
       "Definition": "pond"
     },
     {
+      "ID": "N5#53",
       "Kana": "いしゃ",
       "Kanji": "医者",
       "Definition": "doctor (medical)"
     },
     {
+      "ID": "N5#54",
       "Kana": "いす",
       "Kanji": "",
       "Definition": "chair"
     },
     {
+      "ID": "N5#55",
       "Kana": "いそがしい",
       "Kanji": "忙しい",
       "Definition": "busy, irritated"
     },
     {
+      "ID": "N5#56",
       "Kana": "いたい",
       "Kanji": "痛い",
       "Definition": "painful"
     },
     {
+      "ID": "N5#57",
       "Kana": "いち",
       "Kanji": "一",
       "Definition": "one"
     },
     {
+      "ID": "N5#58",
       "Kana": "いちにち",
       "Kanji": "一日",
       "Definition": "1 day (duration)"
     },
     {
+      "ID": "N5#59",
       "Kana": "いちばん",
       "Kanji": "",
       "Definition": "best, first, number one"
     },
     {
+      "ID": "N5#60",
       "Kana": "いつ",
       "Kanji": "",
       "Definition": "when"
     },
     {
+      "ID": "N5#61",
       "Kana": "いつか",
       "Kanji": "五日",
       "Definition": "five days, the fifth day (of the month)"
     },
     {
+      "ID": "N5#62",
       "Kana": "いっしょ",
       "Kanji": "一緒",
       "Definition": "together"
     },
     {
+      "ID": "N5#63",
       "Kana": "いつつ",
       "Kanji": "五つ",
       "Definition": "five"
     },
     {
+      "ID": "N5#64",
       "Kana": "いつも",
       "Kanji": "",
       "Definition": "always, every time"
     },
     {
+      "ID": "N5#65",
       "Kana": "いぬ",
       "Kanji": "犬",
       "Definition": "dog"
     },
     {
+      "ID": "N5#66",
       "Kana": "いま",
       "Kanji": "今",
       "Definition": "now"
     },
     {
+      "ID": "N5#67",
       "Kana": "いみ",
       "Kanji": "意味",
       "Definition": "meaning"
     },
     {
+      "ID": "N5#68",
       "Kana": "いもうと",
       "Kanji": "妹",
       "Definition": "younger sister"
     },
     {
+      "ID": "N5#69",
       "Kana": "いや",
       "Kanji": "嫌",
       "Definition": "disagreeable, no"
     },
     {
+      "ID": "N5#70",
       "Kana": "いりぐち",
       "Kanji": "入口",
       "Definition": "entrance, gate"
     },
     {
+      "ID": "N5#71",
       "Kana": "いる",
       "Kanji": "居る",
       "Definition": "(hum) to be (animate), to exist"
     },
     {
+      "ID": "N5#72",
       "Kana": "いる",
       "Kanji": "要る",
       "Definition": "to need"
     },
     {
+      "ID": "N5#73",
       "Kana": "いれる",
       "Kanji": "入れる",
       "Definition": "to put in"
     },
     {
+      "ID": "N5#74",
       "Kana": "いろ",
       "Kanji": "色",
       "Definition": "colour"
     },
     {
+      "ID": "N5#75",
       "Kana": "いろいろ",
       "Kanji": "",
       "Definition": "various"
@@ -380,56 +455,67 @@
   ],
   "う": [
     {
+      "ID": "N5#76",
       "Kana": "うえ",
       "Kanji": "上",
       "Definition": "above, on top of"
     },
     {
+      "ID": "N5#77",
       "Kana": "うしろ",
       "Kanji": "後ろ",
       "Definition": "behind, rear"
     },
     {
+      "ID": "N5#78",
       "Kana": "うすい",
       "Kanji": "薄い",
       "Definition": "thin, weak"
     },
     {
+      "ID": "N5#79",
       "Kana": "うた",
       "Kanji": "歌",
       "Definition": "song"
     },
     {
+      "ID": "N5#80",
       "Kana": "うたう",
       "Kanji": "歌う",
       "Definition": "to sing"
     },
     {
+      "ID": "N5#81",
       "Kana": "うち",
       "Kanji": "",
       "Definition": "house (one's own)"
     },
     {
+      "ID": "N5#82",
       "Kana": "うまれる",
       "Kanji": "生まれる",
       "Definition": "to be born"
     },
     {
+      "ID": "N5#83",
       "Kana": "うみ",
       "Kanji": "海",
       "Definition": "sea, beach"
     },
     {
+      "ID": "N5#84",
       "Kana": "うる",
       "Kanji": "売る",
       "Definition": "to sell"
     },
     {
+      "ID": "N5#85",
       "Kana": "うるさい",
       "Kanji": "",
       "Definition": "noisy, loud, annoying"
     },
     {
+      "ID": "N5#86",
       "Kana": "うわぎ",
       "Kanji": "上着",
       "Definition": "coat, jacket"
@@ -437,41 +523,49 @@
   ],
   "え": [
     {
+      "ID": "N5#87",
       "Kana": "え",
       "Kanji": "絵",
       "Definition": "picture, drawing, painting, sketch"
     },
     {
+      "ID": "N5#88",
       "Kana": "えいが",
       "Kanji": "映画",
       "Definition": "movie, film"
     },
     {
+      "ID": "N5#89",
       "Kana": "えいがかん",
       "Kanji": "映画館",
       "Definition": "movie theatre (theater), cinema"
     },
     {
+      "ID": "N5#90",
       "Kana": "えいご",
       "Kanji": "英語",
       "Definition": "the English language"
     },
     {
+      "ID": "N5#91",
       "Kana": "ええ",
       "Kanji": "",
       "Definition": "yes"
     },
     {
+      "ID": "N5#92",
       "Kana": "えき",
       "Kanji": "駅",
       "Definition": "station"
     },
     {
+      "ID": "N5#93",
       "Kana": "エレベーター",
       "Kanji": "",
       "Definition": "elevator"
     },
     {
+      "ID": "N5#94",
       "Kana": "えんぴつ",
       "Kanji": "鉛筆",
       "Definition": "pencil"
@@ -479,226 +573,271 @@
   ],
   "お": [
     {
+      "ID": "N5#95",
       "Kana": "おいしい",
       "Kanji": "",
       "Definition": "delicious, tasty"
     },
     {
+      "ID": "N5#96",
       "Kana": "おおい",
       "Kanji": "多い",
       "Definition": "many"
     },
     {
+      "ID": "N5#97",
       "Kana": "おおきい",
       "Kanji": "大きい",
       "Definition": "big"
     },
     {
+      "ID": "N5#98",
       "Kana": "おおきな",
       "Kanji": "大きな",
       "Definition": "big"
     },
     {
+      "ID": "N5#99",
       "Kana": "おおぜい",
       "Kanji": "大勢",
       "Definition": "great number of people"
     },
     {
+      "ID": "N5#100",
       "Kana": "おかあさん",
       "Kanji": "お母さん",
       "Definition": "(hon) mother"
     },
     {
+      "ID": "N5#101",
       "Kana": "おかし",
       "Kanji": "お菓子",
       "Definition": "confections, sweets, candy"
     },
     {
+      "ID": "N5#102",
       "Kana": "おかね",
       "Kanji": "お金",
       "Definition": "money"
     },
     {
+      "ID": "N5#103",
       "Kana": "おきる",
       "Kanji": "起きる",
       "Definition": "to get up, to rise"
     },
     {
+      "ID": "N5#104",
       "Kana": "おく",
       "Kanji": "置く",
       "Definition": "to put, to place"
     },
     {
+      "ID": "N5#105",
       "Kana": "おくさん",
       "Kanji": "奥さん",
       "Definition": "(hon) wife"
     },
     {
+      "ID": "N5#106",
       "Kana": "おさけ",
       "Kanji": "お酒",
       "Definition": "alcohol, sake (rice wine)"
     },
     {
+      "ID": "N5#107",
       "Kana": "おさら",
       "Kanji": "お皿",
       "Definition": "plate, dish"
     },
     {
+      "ID": "N5#108",
       "Kana": "おじさん",
       "Kanji": "伯父/叔父・さん",
       "Definition": "uncle, middle aged man"
     },
     {
+      "ID": "N5#109",
       "Kana": "おじいさん",
       "Kanji": "",
       "Definition": "grandfather, male senior citizen"
     },
     {
+      "ID": "N5#110",
       "Kana": "おしえる",
       "Kanji": "教える",
       "Definition": "to teach, to inform"
     },
     {
+      "ID": "N5#111",
       "Kana": "おす",
       "Kanji": "押す",
       "Definition": "to push, to press"
     },
     {
+      "ID": "N5#112",
       "Kana": "おそい",
       "Kanji": "遅い",
       "Definition": "late, slow"
     },
     {
+      "ID": "N5#113",
       "Kana": "おちゃ",
       "Kanji": "お茶",
       "Definition": "tea (green)"
     },
     {
+      "ID": "N5#114",
       "Kana": "おてあらい",
       "Kanji": "お手洗い",
       "Definition": "toilet, lavatory, bathroom"
     },
     {
+      "ID": "N5#115",
       "Kana": "おとうさん",
       "Kanji": "お父さん",
       "Definition": "(hon) father"
     },
     {
+      "ID": "N5#116",
       "Kana": "おとうと",
       "Kanji": "弟",
       "Definition": "younger brother"
     },
     {
+      "ID": "N5#117",
       "Kana": "おとこ",
       "Kanji": "男",
       "Definition": "man"
     },
     {
+      "ID": "N5#118",
       "Kana": "おとこのこ",
       "Kanji": "男の子",
       "Definition": "boy"
     },
     {
+      "ID": "N5#119",
       "Kana": "おととい",
       "Kanji": "",
       "Definition": "day before yesterday"
     },
     {
+      "ID": "N5#120",
       "Kana": "おととし",
       "Kanji": "",
       "Definition": "year before last"
     },
     {
+      "ID": "N5#121",
       "Kana": "おとな",
       "Kanji": "大人",
       "Definition": "adult"
     },
     {
+      "ID": "N5#122",
       "Kana": "おなか",
       "Kanji": "",
       "Definition": "stomach"
     },
     {
+      "ID": "N5#123",
       "Kana": "おなじ",
       "Kanji": "同じ",
       "Definition": "same, identical, similar"
     },
     {
+      "ID": "N5#124",
       "Kana": "おにいさん",
       "Kanji": "お兄さん",
       "Definition": "(hon) older brother"
     },
     {
+      "ID": "N5#125",
       "Kana": "おねえさん",
       "Kanji": "お姉さん",
       "Definition": "(hon) older sister"
     },
     {
+      "ID": "N5#126",
       "Kana": "おばさん",
       "Kanji": "伯母さん/叔母さん",
       "Definition": "aunt"
     },
     {
+      "ID": "N5#127",
       "Kana": "おばあさん",
       "Kanji": "",
       "Definition": "grandmother, female senior-citizen"
     },
     {
+      "ID": "N5#128",
       "Kana": "おふろ",
       "Kanji": "お風呂",
       "Definition": "bath"
     },
     {
+      "ID": "N5#129",
       "Kana": "おべんとう",
       "Kanji": "お弁当",
       "Definition": "boxed lunch"
     },
     {
+      "ID": "N5#130",
       "Kana": "おぼえる",
       "Kanji": "覚える",
       "Definition": "to remember, to memorize"
     },
     {
+      "ID": "N5#131",
       "Kana": "おまわりさん",
       "Kanji": "",
       "Definition": "policeman (friendly term)"
     },
     {
+      "ID": "N5#132",
       "Kana": "おもい",
       "Kanji": "重い",
       "Definition": "heavy"
     },
     {
+      "ID": "N5#133",
       "Kana": "おもしろい",
       "Kanji": "",
       "Definition": "interesting, amusing"
     },
     {
+      "ID": "N5#134",
       "Kana": "およぐ",
       "Kanji": "泳ぐ",
       "Definition": "to swim"
     },
     {
+      "ID": "N5#135",
       "Kana": "おりる",
       "Kanji": "降りる",
       "Definition": "to alight (eg from bus), to get off"
     },
     {
+      "ID": "N5#136",
       "Kana": "おわる",
       "Kanji": "終る",
       "Definition": "to finish, to close"
     },
     {
+      "ID": "N5#137",
       "Kana": "おんがく",
       "Kanji": "音楽",
       "Definition": "music"
     },
     {
+      "ID": "N5#138",
       "Kana": "おんな",
       "Kanji": "女",
       "Definition": "woman, girl, daughter"
     },
     {
+      "ID": "N5#139",
       "Kana": "おんなのこ",
       "Kanji": "女の子",
       "Definition": "girl"
@@ -706,196 +845,223 @@
   ],
   "か": [
     {
-      "Kana": "がいこく",
-      "Kanji": "外国",
-      "Definition": "foreign country"
-    },
-    {
-      "Kana": "がいこくじん",
-      "Kanji": "外国人",
-      "Definition": "foreigner"
-    },
-    {
+      "ID": "N5#140",
       "Kana": "かいしゃ",
       "Kanji": "会社",
       "Definition": "company, corporation"
     },
     {
+      "ID": "N5#141",
       "Kana": "かいだん",
       "Kanji": "階段",
       "Definition": "stairs"
     },
     {
+      "ID": "N5#142",
       "Kana": "かいもの",
       "Kanji": "買い物",
       "Definition": "shopping"
     },
     {
+      "ID": "N5#143",
       "Kana": "かう",
       "Kanji": "買う",
       "Definition": "to buy"
     },
     {
+      "ID": "N5#144",
       "Kana": "かえす",
       "Kanji": "返す",
       "Definition": "to return something"
     },
     {
+      "ID": "N5#145",
       "Kana": "かえる",
       "Kanji": "帰る",
       "Definition": "to go home, to return"
     },
     {
+      "ID": "N5#146",
       "Kana": "かお",
       "Kanji": "顔",
       "Definition": "face (person)"
     },
     {
+      "ID": "N5#147",
       "Kana": "かかる",
       "Kanji": "",
       "Definition": "to take (eg time, money)"
     },
     {
+      "ID": "N5#148",
       "Kana": "かぎ",
       "Kanji": "",
       "Definition": "key/s"
     },
     {
+      "ID": "N5#149",
       "Kana": "かく",
       "Kanji": "書く",
       "Definition": "to write"
     },
     {
+      "ID": "N5#150",
       "Kana": "かける",
       "Kanji": "",
       "Definition": "to put on (eg glasses)"
     },
     {
+      "ID": "N5#151",
       "Kana": "かける",
       "Kanji": "",
       "Definition": "to dial/call (eg phone)"
     },
     {
+      "ID": "N5#152",
       "Kana": "かさ",
       "Kanji": "傘",
       "Definition": "umbrella"
     },
     {
+      "ID": "N5#153",
       "Kana": "かす",
       "Kanji": "貸す",
       "Definition": "to lend"
     },
     {
+      "ID": "N5#154",
       "Kana": "かぜ",
       "Kanji": "風",
       "Definition": "wind, breeze"
     },
     {
+      "ID": "N5#155",
       "Kana": "かぜ",
       "Kanji": "風邪",
       "Definition": "cold, illness"
     },
     {
+      "ID": "N5#156",
       "Kana": "かた",
       "Kanji": "方",
       "Definition": "person"
     },
     {
+      "ID": "N5#157",
       "Kana": "かぞく",
       "Kanji": "家族",
       "Definition": "family"
     },
     {
+      "ID": "N5#158",
       "Kana": "かたかな",
       "Kanji": "片仮名",
       "Definition": "katakana"
     },
     {
+      "ID": "N5#159",
       "Kana": "カップ",
       "Kanji": "",
       "Definition": "cup"
     },
     {
+      "ID": "N5#160",
       "Kana": "かてい",
       "Kanji": "家庭",
       "Definition": "home, household"
     },
     {
+      "ID": "N5#161",
       "Kana": "かど",
       "Kanji": "角",
       "Definition": "corner (e.g. desk)"
     },
     {
+      "ID": "N5#162",
       "Kana": "かばん",
       "Kanji": "",
       "Definition": "bag, basket"
     },
     {
+      "ID": "N5#163",
       "Kana": "かびん",
       "Kanji": "花瓶",
       "Definition": "(flower) vase"
     },
     {
+      "ID": "N5#164",
       "Kana": "かぶる",
       "Kanji": "",
       "Definition": "to wear, to put on (head)"
     },
     {
+      "ID": "N5#165",
       "Kana": "かみ",
       "Kanji": "紙",
       "Definition": "paper"
     },
     {
+      "ID": "N5#166",
       "Kana": "カメラ",
       "Kanji": "",
       "Definition": "camera"
     },
     {
+      "ID": "N5#167",
       "Kana": "かようび",
       "Kanji": "火曜日",
       "Definition": "Tuesday"
     },
     {
+      "ID": "N5#168",
       "Kana": "からい",
       "Kanji": "辛い",
       "Definition": "spicy, salty"
     },
     {
+      "ID": "N5#169",
       "Kana": "からだ",
       "Kanji": "体",
       "Definition": "body"
     },
     {
+      "ID": "N5#170",
       "Kana": "かりる",
       "Kanji": "借りる",
       "Definition": "to borrow, to have a loan"
     },
     {
+      "ID": "N5#171",
       "Kana": "かるい",
       "Kanji": "軽い",
       "Definition": "light, non-serious, minor"
     },
     {
+      "ID": "N5#172",
       "Kana": "カレー",
       "Kanji": "",
       "Definition": "curry"
     },
     {
+      "ID": "N5#173",
       "Kana": "カレンダー",
       "Kanji": "",
       "Definition": "calendar"
     },
     {
+      "ID": "N5#174",
       "Kana": "かわ",
       "Kanji": "川/河",
       "Definition": "river"
     },
     {
+      "ID": "N5#175",
       "Kana": "かわいい",
       "Kanji": "",
       "Definition": "cute, charming"
     },
     {
+      "ID": "N5#176",
       "Kana": "かんじ",
       "Kanji": "漢字",
       "Definition": "kanji, Chinese character"
@@ -903,11 +1069,25 @@
   ],
   "が": [
     {
+      "ID": "N5#177",
+      "Kana": "がいこく",
+      "Kanji": "外国",
+      "Definition": "foreign country"
+    },
+    {
+      "ID": "N5#178",
+      "Kana": "がいこくじん",
+      "Kanji": "外国人",
+      "Definition": "foreigner"
+    },
+    {
+      "ID": "N5#179",
       "Kana": "がくせい",
       "Kanji": "学生",
       "Definition": "student"
     },
     {
+      "ID": "N5#180",
       "Kana": "がっこう",
       "Kanji": "学校",
       "Definition": "school"
@@ -915,116 +1095,139 @@
   ],
   "き": [
     {
+      "ID": "N5#181",
       "Kana": "き",
       "Kanji": "木",
       "Definition": "tree, wood"
     },
     {
+      "ID": "N5#182",
       "Kana": "きいろ",
       "Kanji": "黄色",
       "Definition": "yellow"
     },
     {
+      "ID": "N5#183",
       "Kana": "きいろい",
       "Kanji": "黄色い",
       "Definition": "yellow"
     },
     {
+      "ID": "N5#184",
       "Kana": "きえる",
       "Kanji": "消える",
       "Definition": "to go out, to vanish"
     },
     {
+      "ID": "N5#185",
       "Kana": "きく",
       "Kanji": "聞く",
       "Definition": "to hear, to listen, to ask"
     },
     {
+      "ID": "N5#186",
       "Kana": "きた",
       "Kanji": "北",
       "Definition": "north"
     },
     {
+      "ID": "N5#187",
       "Kana": "きたない",
       "Kanji": "汚い",
       "Definition": "dirty, messy"
     },
     {
+      "ID": "N5#188",
       "Kana": "きっさてん",
       "Kanji": "喫茶店",
       "Definition": "coffee lounge"
     },
     {
+      "ID": "N5#189",
       "Kana": "きって",
       "Kanji": "切手",
       "Definition": "stamp (eg. postage)"
     },
     {
+      "ID": "N5#190",
       "Kana": "きっぷ",
       "Kanji": "切符",
       "Definition": "ticket"
     },
     {
+      "ID": "N5#191",
       "Kana": "きのう",
       "Kanji": "昨日",
       "Definition": "yesterday"
     },
     {
+      "ID": "N5#192",
       "Kana": "きゅう",
       "Kanji": "九",
       "Definition": "nine"
     },
     {
+      "ID": "N5#193",
       "Kana": "きょう",
       "Kanji": "今日",
       "Definition": "today, this day"
     },
     {
+      "ID": "N5#194",
       "Kana": "きょうしつ",
       "Kanji": "教室",
       "Definition": "classroom"
     },
     {
+      "ID": "N5#195",
       "Kana": "きょうだい",
       "Kanji": "兄弟",
       "Definition": "siblings (brothers and sisters)"
     },
     {
+      "ID": "N5#196",
       "Kana": "きょねん",
       "Kanji": "去年",
       "Definition": "last year"
     },
     {
+      "ID": "N5#197",
       "Kana": "きらい",
       "Kanji": "嫌い",
       "Definition": "dislike, hate"
     },
     {
+      "ID": "N5#198",
       "Kana": "きる",
       "Kanji": "切る",
       "Definition": "to cut, to chop"
     },
     {
+      "ID": "N5#199",
       "Kana": "きる",
       "Kanji": "着る",
       "Definition": "to wear, to put on (from shoulders down)"
     },
     {
+      "ID": "N5#200",
       "Kana": "きれい",
       "Kanji": "",
       "Definition": "pretty, clean, nice, tidy"
     },
     {
+      "ID": "N5#201",
       "Kana": "キログラム",
       "Kanji": "",
       "Definition": "kilo (kilogram)"
     },
     {
+      "ID": "N5#202",
       "Kana": "キロメートル",
       "Kanji": "",
       "Definition": "kilo (kilometre)"
     },
     {
+      "ID": "N5#203",
       "Kana": "きんようび",
       "Kanji": "金曜日",
       "Definition": "Friday"
@@ -1032,21 +1235,25 @@
   ],
   "ぎ": [
     {
+      "ID": "N5#204",
       "Kana": "ギター",
       "Kanji": "",
       "Definition": "guitar"
     },
     {
+      "ID": "N5#205",
       "Kana": "ぎゅうにく",
       "Kanji": "牛肉",
       "Definition": "beef"
     },
     {
+      "ID": "N5#206",
       "Kana": "ぎゅうにゅう",
       "Kanji": "牛乳",
       "Definition": "milk"
     },
     {
+      "ID": "N5#207",
       "Kana": "ぎんこう",
       "Kanji": "銀行",
       "Definition": "bank"
@@ -1054,81 +1261,97 @@
   ],
   "く": [
     {
+      "ID": "N5#208",
       "Kana": "く",
       "Kanji": "九",
       "Definition": "nine"
     },
     {
+      "ID": "N5#209",
       "Kana": "くすり",
       "Kanji": "薬",
       "Definition": "medicine"
     },
     {
+      "ID": "N5#210",
       "Kana": "ください",
       "Kanji": "",
       "Definition": "(with te-form verb) please do for me"
     },
     {
+      "ID": "N5#211",
       "Kana": "くだもの",
       "Kanji": "果物",
       "Definition": "fruit"
     },
     {
+      "ID": "N5#212",
       "Kana": "くち",
       "Kanji": "口",
       "Definition": "mouth, orifice, opening"
     },
     {
+      "ID": "N5#213",
       "Kana": "くつ",
       "Kanji": "靴",
       "Definition": "shoes, footwear"
     },
     {
+      "ID": "N5#214",
       "Kana": "くつした",
       "Kanji": "靴下",
       "Definition": "socks"
     },
     {
+      "ID": "N5#215",
       "Kana": "くに",
       "Kanji": "国",
       "Definition": "country"
     },
     {
+      "ID": "N5#216",
       "Kana": "くもり",
       "Kanji": "曇り",
       "Definition": "cloudiness, cloudy weather"
     },
     {
+      "ID": "N5#217",
       "Kana": "くもる",
       "Kanji": "曇る",
       "Definition": "to become cloudy, to become dim"
     },
     {
+      "ID": "N5#218",
       "Kana": "くらい",
       "Kanji": "暗い",
       "Definition": "dark, gloomy"
     },
     {
+      "ID": "N5#219",
       "Kana": "クラス",
       "Kanji": "",
       "Definition": "class"
     },
     {
+      "ID": "N5#220",
       "Kana": "くる",
       "Kanji": "来る",
       "Definition": "to come"
     },
     {
+      "ID": "N5#221",
       "Kana": "くるま",
       "Kanji": "車",
       "Definition": "car, vehicle"
     },
     {
+      "ID": "N5#222",
       "Kana": "くろ",
       "Kanji": "黒",
       "Definition": "black"
     },
     {
+      "ID": "N5#223",
       "Kana": "くろい",
       "Kanji": "黒い",
       "Definition": "black"
@@ -1136,6 +1359,7 @@
   ],
   "ぐ": [
     {
+      "ID": "N5#224",
       "Kana": "グラム",
       "Kanji": "",
       "Definition": "gram"
@@ -1143,31 +1367,37 @@
   ],
   "け": [
     {
+      "ID": "N5#225",
       "Kana": "けいかん",
       "Kanji": "警官",
       "Definition": "policeman"
     },
     {
+      "ID": "N5#226",
       "Kana": "けさ",
       "Kanji": "今朝",
       "Definition": "this morning"
     },
     {
+      "ID": "N5#227",
       "Kana": "けす",
       "Kanji": "消す",
       "Definition": "to erase, to delete, to turn off power"
     },
     {
+      "ID": "N5#228",
       "Kana": "けっこう",
       "Kanji": "結構",
       "Definition": "nice, enough"
     },
     {
+      "ID": "N5#229",
       "Kana": "けっこん",
       "Kanji": "結婚",
       "Definition": "marriage"
     },
     {
+      "ID": "N5#230",
       "Kana": "けっこんする",
       "Kanji": "結婚する",
       "Definition": "to get married"
@@ -1175,16 +1405,19 @@
   ],
   "げ": [
     {
+      "ID": "N5#231",
       "Kana": "げつようび",
       "Kanji": "月曜日",
       "Definition": "Monday"
     },
     {
+      "ID": "N5#232",
       "Kana": "げんかん",
       "Kanji": "玄関",
       "Definition": "entrance-way, entry hall"
     },
     {
+      "ID": "N5#233",
       "Kana": "げんき",
       "Kanji": "元気",
       "Definition": "health"
@@ -1192,131 +1425,157 @@
   ],
   "こ": [
     {
+      "ID": "N5#234",
       "Kana": "こうえん",
       "Kanji": "公園",
       "Definition": "(public) park"
     },
     {
+      "ID": "N5#235",
       "Kana": "こうさてん",
       "Kanji": "交差点",
       "Definition": "intersection"
     },
     {
+      "ID": "N5#236",
       "Kana": "こうちゃ",
       "Kanji": "紅茶",
       "Definition": "black tea"
     },
     {
+      "ID": "N5#237",
       "Kana": "こうばん",
       "Kanji": "交番",
       "Definition": "police box"
     },
     {
+      "ID": "N5#238",
       "Kana": "こえ",
       "Kanji": "声",
       "Definition": "voice"
     },
     {
+      "ID": "N5#239",
       "Kana": "コート",
       "Kanji": "",
       "Definition": "coat"
     },
     {
+      "ID": "N5#240",
       "Kana": "コーヒー",
       "Kanji": "",
       "Definition": "coffee"
     },
     {
+      "ID": "N5#241",
       "Kana": "ここ",
       "Kanji": "",
       "Definition": "here, this place"
     },
     {
+      "ID": "N5#242",
       "Kana": "ここのか",
       "Kanji": "九日",
       "Definition": "nine days, the ninth day (of the month)"
     },
     {
+      "ID": "N5#243",
       "Kana": "ここのつ",
       "Kanji": "九つ",
       "Definition": "nine"
     },
     {
+      "ID": "N5#244",
       "Kana": "こたえる",
       "Kanji": "答える",
       "Definition": "to answer, to reply"
     },
     {
+      "ID": "N5#245",
       "Kana": "こちら",
       "Kanji": "",
       "Definition": "this eg person, way"
     },
     {
+      "ID": "N5#246",
       "Kana": "こっち",
       "Kanji": "",
       "Definition": "this eg person, way"
     },
     {
+      "ID": "N5#247",
       "Kana": "コップ",
       "Kanji": "",
       "Definition": "cup"
     },
     {
+      "ID": "N5#248",
       "Kana": "ことし",
       "Kanji": "今年",
       "Definition": "this year"
     },
     {
+      "ID": "N5#249",
       "Kana": "ことば",
       "Kanji": "言葉",
       "Definition": "word"
     },
     {
+      "ID": "N5#250",
       "Kana": "こども",
       "Kanji": "子供",
       "Definition": "child, children"
     },
     {
+      "ID": "N5#251",
       "Kana": "この",
       "Kanji": "",
       "Definition": "this"
     },
     {
+      "ID": "N5#252",
       "Kana": "コピー",
       "Kanji": "",
       "Definition": "a copy"
     },
     {
+      "ID": "N5#253",
       "Kana": "コピーする",
       "Kanji": "",
       "Definition": "to copy"
     },
     {
+      "ID": "N5#254",
       "Kana": "こまる",
       "Kanji": "困る",
       "Definition": "to be worried, to be bothered"
     },
     {
+      "ID": "N5#255",
       "Kana": "これ",
       "Kanji": "",
       "Definition": "this"
     },
     {
+      "ID": "N5#256",
       "Kana": "こんげつ",
       "Kanji": "今月",
       "Definition": "this month"
     },
     {
+      "ID": "N5#257",
       "Kana": "こんしゅう",
       "Kanji": "今週",
       "Definition": "this week"
     },
     {
+      "ID": "N5#258",
       "Kana": "こんな",
       "Kanji": "",
       "Definition": "such, like this"
     },
     {
+      "ID": "N5#259",
       "Kana": "こんばん",
       "Kanji": "今晩",
       "Definition": "tonight, this evening"
@@ -1324,21 +1583,25 @@
   ],
   "ご": [
     {
+      "ID": "N5#260",
       "Kana": "ご",
       "Kanji": "五",
       "Definition": "five"
     },
     {
+      "ID": "N5#261",
       "Kana": "ごご",
       "Kanji": "午後",
       "Definition": "afternoon, P.M."
     },
     {
+      "ID": "N5#262",
       "Kana": "ごぜん",
       "Kanji": "午前",
       "Definition": "morning, A.M."
     },
     {
+      "ID": "N5#263",
       "Kana": "ごはん",
       "Kanji": "御飯",
       "Definition": "rice (cooked), meal"
@@ -1346,66 +1609,79 @@
   ],
   "さ": [
     {
+      "ID": "N5#264",
       "Kana": "さあ",
       "Kanji": "",
       "Definition": "come now, well"
     },
     {
+      "ID": "N5#265",
       "Kana": "さいふ",
       "Kanji": "財布",
       "Definition": "wallet"
     },
     {
+      "ID": "N5#266",
       "Kana": "さかな",
       "Kanji": "魚",
       "Definition": "fish"
     },
     {
+      "ID": "N5#267",
       "Kana": "さき",
       "Kanji": "先",
       "Definition": "the future, former, previous"
     },
     {
+      "ID": "N5#268",
       "Kana": "さく",
       "Kanji": "咲く",
       "Definition": "to bloom"
     },
     {
+      "ID": "N5#269",
       "Kana": "さくぶん",
       "Kanji": "作文",
       "Definition": "composition, writing"
     },
     {
+      "ID": "N5#270",
       "Kana": "さす",
       "Kanji": "差す",
       "Definition": "to raise (stretch out) hands, to raise (eg umbrella)"
     },
     {
+      "ID": "N5#271",
       "Kana": "さとう",
       "Kanji": "砂糖",
       "Definition": "sugar"
     },
     {
+      "ID": "N5#272",
       "Kana": "さむい",
       "Kanji": "寒い",
       "Definition": "cold (e.g. weather)"
     },
     {
+      "ID": "N5#273",
       "Kana": "さらいねん",
       "Kanji": "さ来年",
       "Definition": "year after next"
     },
     {
+      "ID": "N5#274",
       "Kana": "さん",
       "Kanji": "三",
       "Definition": "three"
     },
     {
+      "ID": "N5#275",
       "Kana": "さんぽ",
       "Kanji": "散歩",
       "Definition": "a walk, stroll"
     },
     {
+      "ID": "N5#276",
       "Kana": "さんぽする",
       "Kanji": "散歩する",
       "Definition": "to walk or to go for a stroll"
@@ -1413,6 +1689,7 @@
   ],
   "ざ": [
     {
+      "ID": "N5#277",
       "Kana": "ざっし",
       "Kanji": "雑誌",
       "Definition": "magazine"
@@ -1420,111 +1697,133 @@
   ],
   "し": [
     {
+      "ID": "N5#278",
       "Kana": "し",
       "Kanji": "四",
       "Definition": "four"
     },
     {
+      "ID": "N5#279",
       "Kana": "しお",
       "Kanji": "塩",
       "Definition": "salt"
     },
     {
+      "ID": "N5#280",
       "Kana": "しかし",
       "Kanji": "",
       "Definition": "however, but"
     },
     {
+      "ID": "N5#281",
       "Kana": "しごと",
       "Kanji": "仕事",
       "Definition": "work, occupation, employment"
     },
     {
+      "ID": "N5#282",
       "Kana": "しずか",
       "Kanji": "静か",
       "Definition": "quiet, peaceful"
     },
     {
+      "ID": "N5#283",
       "Kana": "した",
       "Kanji": "下",
       "Definition": "under, below, beneath"
     },
     {
+      "ID": "N5#284",
       "Kana": "しち",
       "Kanji": "七",
       "Definition": "seven"
     },
     {
+      "ID": "N5#285",
       "Kana": "しつもん",
       "Kanji": "質問",
       "Definition": "question, inquiry"
     },
     {
+      "ID": "N5#286",
       "Kana": "しぬ",
       "Kanji": "死ぬ",
       "Definition": "to die"
     },
     {
+      "ID": "N5#287",
       "Kana": "しまる",
       "Kanji": "閉まる",
       "Definition": "to close, to be closed"
     },
     {
+      "ID": "N5#288",
       "Kana": "しめる",
       "Kanji": "閉める",
       "Definition": "to close, to shut"
     },
     {
+      "ID": "N5#289",
       "Kana": "しめる",
       "Kanji": "締める",
       "Definition": "to tie, to fasten"
     },
     {
+      "ID": "N5#290",
       "Kana": "しゃしん",
       "Kanji": "写真",
       "Definition": "photograph"
     },
     {
+      "ID": "N5#291",
       "Kana": "シャツ",
       "Kanji": "",
       "Definition": "shirt, singlet"
     },
     {
+      "ID": "N5#292",
       "Kana": "シャワー",
       "Kanji": "",
       "Definition": "shower"
     },
     {
+      "ID": "N5#293",
       "Kana": "しゅくだい",
       "Kanji": "宿題",
       "Definition": "homework"
     },
     {
+      "ID": "N5#294",
       "Kana": "しょうゆ",
       "Kanji": "",
       "Definition": "soy sauce"
     },
     {
+      "ID": "N5#295",
       "Kana": "しょくどう",
       "Kanji": "食堂",
       "Definition": "cafeteria, dining hall"
     },
     {
+      "ID": "N5#296",
       "Kana": "しる",
       "Kanji": "知る",
       "Definition": "to know, to understand"
     },
     {
+      "ID": "N5#297",
       "Kana": "しろ",
       "Kanji": "白",
       "Definition": "white"
     },
     {
+      "ID": "N5#298",
       "Kana": "しろい",
       "Kanji": "白い",
       "Definition": "white"
     },
     {
+      "ID": "N5#299",
       "Kana": "しんぶん",
       "Kanji": "新聞",
       "Definition": "newspaper"
@@ -1532,61 +1831,73 @@
   ],
   "じ": [
     {
+      "ID": "N5#300",
       "Kana": "じかん",
       "Kanji": "時間",
       "Definition": "time"
     },
     {
+      "ID": "N5#301",
       "Kana": "じしょ",
       "Kanji": "辞書",
       "Definition": "dictionary"
     },
     {
+      "ID": "N5#302",
       "Kana": "じてんしゃ",
       "Kanji": "自転車",
       "Definition": "bicycle"
     },
     {
+      "ID": "N5#303",
       "Kana": "じどうしゃ",
       "Kanji": "自動車",
       "Definition": "automobile"
     },
     {
+      "ID": "N5#304",
       "Kana": "じびき",
       "Kanji": "字引",
       "Definition": "dictionary"
     },
     {
+      "ID": "N5#305",
       "Kana": "じぶん",
       "Kanji": "自分",
       "Definition": "myself, oneself"
     },
     {
+      "ID": "N5#306",
       "Kana": "じゃ",
       "Kanji": "",
       "Definition": "well, well then"
     },
     {
+      "ID": "N5#307",
       "Kana": "じゃあ",
       "Kanji": "",
       "Definition": "well, well then"
     },
     {
+      "ID": "N5#308",
       "Kana": "じゅう",
       "Kanji": "十",
       "Definition": "ten"
     },
     {
+      "ID": "N5#309",
       "Kana": "じゅぎょう",
       "Kanji": "授業",
       "Definition": "lesson, class work"
     },
     {
+      "ID": "N5#310",
       "Kana": "じょうず",
       "Kanji": "上手",
       "Definition": "skill, skillful, dexterity"
     },
     {
+      "ID": "N5#311",
       "Kana": "じょうぶ",
       "Kanji": "丈夫",
       "Definition": "strong, solid, durable"
@@ -1594,76 +1905,91 @@
   ],
   "す": [
     {
+      "ID": "N5#312",
       "Kana": "すいようび",
       "Kanji": "水曜日",
       "Definition": "Wednesday"
     },
     {
+      "ID": "N5#313",
       "Kana": "すう",
       "Kanji": "吸う",
       "Definition": "to smoke, to breathe in, to suck"
     },
     {
+      "ID": "N5#314",
       "Kana": "スカート",
       "Kanji": "",
       "Definition": "skirt"
     },
     {
+      "ID": "N5#315",
       "Kana": "すき",
       "Kanji": "好き",
       "Definition": "liking, fondness, love"
     },
     {
+      "ID": "N5#316",
       "Kana": "すくない",
       "Kanji": "少ない",
       "Definition": "a few, scarce"
     },
     {
+      "ID": "N5#317",
       "Kana": "すぐ",
       "Kanji": "",
       "Definition": "immediately, instantly"
     },
     {
+      "ID": "N5#318",
       "Kana": "すこし",
       "Kanji": "少し",
       "Definition": "little, few"
     },
     {
+      "ID": "N5#319",
       "Kana": "すずしい",
       "Kanji": "涼しい",
       "Definition": "cool, refreshing"
     },
     {
+      "ID": "N5#320",
       "Kana": "ストーブ",
       "Kanji": "",
       "Definition": "heater (lit: stove)"
     },
     {
+      "ID": "N5#321",
       "Kana": "スプーン",
       "Kanji": "",
       "Definition": "spoon"
     },
     {
+      "ID": "N5#322",
       "Kana": "スポーツ",
       "Kanji": "",
       "Definition": "sport"
     },
     {
+      "ID": "N5#323",
       "Kana": "すむ",
       "Kanji": "住む",
       "Definition": "to reside, to live in"
     },
     {
+      "ID": "N5#324",
       "Kana": "スリッパ",
       "Kanji": "",
       "Definition": "slippers"
     },
     {
+      "ID": "N5#325",
       "Kana": "する",
       "Kanji": "",
       "Definition": "to do, to try"
     },
     {
+      "ID": "N5#326",
       "Kana": "すわる",
       "Kanji": "座る",
       "Definition": "to sit"
@@ -1671,6 +1997,7 @@
   ],
   "ず": [
     {
+      "ID": "N5#327",
       "Kana": "ズボン",
       "Kanji": "",
       "Definition": "trousers (fr: jupon)"
@@ -1678,56 +2005,67 @@
   ],
   "せ": [
     {
+      "ID": "N5#328",
       "Kana": "せい",
       "Kanji": "背",
       "Definition": "height, stature"
     },
     {
+      "ID": "N5#329",
       "Kana": "せいと",
       "Kanji": "生徒",
       "Definition": "pupil"
     },
     {
+      "ID": "N5#330",
       "Kana": "セーター",
       "Kanji": "",
       "Definition": "sweater, jumper"
     },
     {
+      "ID": "N5#331",
       "Kana": "せっけん",
       "Kanji": "石鹸",
       "Definition": "soap"
     },
     {
+      "ID": "N5#332",
       "Kana": "せびろ",
       "Kanji": "背広",
       "Definition": "business suit"
     },
     {
+      "ID": "N5#333",
       "Kana": "せまい",
       "Kanji": "狭い",
       "Definition": "narrow, confined, small"
     },
     {
+      "ID": "N5#334",
       "Kana": "せん",
       "Kanji": "千",
       "Definition": "thousand, many"
     },
     {
+      "ID": "N5#335",
       "Kana": "せんげつ",
       "Kanji": "先月",
       "Definition": "last month"
     },
     {
+      "ID": "N5#336",
       "Kana": "せんしゅう",
       "Kanji": "先週",
       "Definition": "last week, the week before"
     },
     {
+      "ID": "N5#337",
       "Kana": "せんせい",
       "Kanji": "先生",
       "Definition": "teacher, master, doctor"
     },
     {
+      "ID": "N5#338",
       "Kana": "せんたく",
       "Kanji": "洗濯",
       "Definition": "washing, laundry"
@@ -1735,11 +2073,13 @@
   ],
   "ぜ": [
     {
+      "ID": "N5#339",
       "Kana": "ゼロ",
       "Kanji": "",
       "Definition": "zero"
     },
     {
+      "ID": "N5#340",
       "Kana": "ぜんぶ",
       "Kanji": "全部",
       "Definition": "all, entire, whole"
@@ -1747,76 +2087,91 @@
   ],
   "そ": [
     {
+      "ID": "N5#341",
       "Kana": "そう",
       "Kanji": "",
       "Definition": "appears, to be the case"
     },
     {
+      "ID": "N5#342",
       "Kana": "そうじ",
       "Kanji": "掃除",
       "Definition": "cleaning, sweeping"
     },
     {
+      "ID": "N5#343",
       "Kana": "そうじする",
       "Kanji": "掃除する",
       "Definition": "to clean, to sweep"
     },
     {
+      "ID": "N5#344",
       "Kana": "そうして",
       "Kanji": "",
       "Definition": "and, like that"
     },
     {
+      "ID": "N5#345",
       "Kana": "そこ",
       "Kanji": "",
       "Definition": "that place, there"
     },
     {
+      "ID": "N5#346",
       "Kana": "そちら",
       "Kanji": "",
       "Definition": "over there"
     },
     {
+      "ID": "N5#347",
       "Kana": "そして",
       "Kanji": "",
       "Definition": "and, like that"
     },
     {
+      "ID": "N5#348",
       "Kana": "そっち",
       "Kanji": "",
       "Definition": "over there"
     },
     {
+      "ID": "N5#349",
       "Kana": "そと",
       "Kanji": "外",
       "Definition": "outside, exterior"
     },
     {
+      "ID": "N5#350",
       "Kana": "その",
       "Kanji": "",
       "Definition": "that"
     },
     {
+      "ID": "N5#351",
       "Kana": "そば",
       "Kanji": "",
       "Definition": "near, close, beside"
     },
     {
+      "ID": "N5#352",
       "Kana": "そら",
       "Kanji": "空",
       "Definition": "sky"
     },
     {
+      "ID": "N5#353",
       "Kana": "それ",
       "Kanji": "",
       "Definition": "it, that"
     },
     {
+      "ID": "N5#354",
       "Kana": "それから",
       "Kanji": "",
       "Definition": "and then, after that"
     },
     {
+      "ID": "N5#355",
       "Kana": "それでは",
       "Kanji": "",
       "Definition": "in that situation, well then..."
@@ -1824,96 +2179,115 @@
   ],
   "た": [
     {
+      "ID": "N5#356",
       "Kana": "たいしかん",
       "Kanji": "大使館",
       "Definition": "embassy"
     },
     {
+      "ID": "N5#357",
       "Kana": "たいせつ",
       "Kanji": "大切",
       "Definition": "important"
     },
     {
+      "ID": "N5#358",
       "Kana": "たいへん",
       "Kanji": "",
       "Definition": "very"
     },
     {
+      "ID": "N5#359",
       "Kana": "たいへん",
       "Kanji": "",
       "Definition": "difficult situation, tough situation"
     },
     {
+      "ID": "N5#360",
       "Kana": "たかい",
       "Kanji": "高い",
       "Definition": "tall, high"
     },
     {
+      "ID": "N5#361",
       "Kana": "たかい",
       "Kanji": "高い",
       "Definition": "expensive"
     },
     {
+      "ID": "N5#362",
       "Kana": "たくさん",
       "Kanji": "",
       "Definition": "many, a lot, much"
     },
     {
+      "ID": "N5#363",
       "Kana": "タクシー",
       "Kanji": "",
       "Definition": "taxi"
     },
     {
+      "ID": "N5#364",
       "Kana": "たつ",
       "Kanji": "立つ",
       "Definition": "to stand"
     },
     {
+      "ID": "N5#365",
       "Kana": "たて",
       "Kanji": "",
       "Definition": "length, height"
     },
     {
+      "ID": "N5#366",
       "Kana": "たてもの",
       "Kanji": "建物",
       "Definition": "building"
     },
     {
+      "ID": "N5#367",
       "Kana": "たのしい",
       "Kanji": "楽しい",
       "Definition": "enjoyable, fun"
     },
     {
+      "ID": "N5#368",
       "Kana": "たのむ",
       "Kanji": "頼む",
       "Definition": "to request, to ask"
     },
     {
+      "ID": "N5#369",
       "Kana": "たばこ",
       "Kanji": "",
       "Definition": "tobacco, cigarettes"
     },
     {
+      "ID": "N5#370",
       "Kana": "たぶん",
       "Kanji": "",
       "Definition": "perhaps, probably"
     },
     {
+      "ID": "N5#371",
       "Kana": "たべもの",
       "Kanji": "食べ物",
       "Definition": "food"
     },
     {
+      "ID": "N5#372",
       "Kana": "たべる",
       "Kanji": "食べる",
       "Definition": "to eat"
     },
     {
+      "ID": "N5#373",
       "Kana": "たまご",
       "Kanji": "卵",
       "Definition": "egg(s)"
     },
     {
+      "ID": "N5#374",
       "Kana": "たんじょうび",
       "Kanji": "誕生日",
       "Definition": "birthday"
@@ -1921,103 +2295,123 @@
   ],
   "だ": [
     {
+      "ID": "N5#375",
       "Kana": "だいがく",
       "Kanji": "大学",
       "Definition": "university"
     },
     {
+      "ID": "N5#376",
       "Kana": "だいじょうぶ",
       "Kanji": "大丈夫",
       "Definition": "safe, all right, O.K."
     },
     {
+      "ID": "N5#377",
       "Kana": "だいすき",
       "Kanji": "大好き",
       "Definition": "very likeable, like very much"
     },
     {
+      "ID": "N5#378",
       "Kana": "だいどころ",
       "Kanji": "台所",
       "Definition": "kitchen"
     },
     {
+      "ID": "N5#379",
       "Kana": "だす",
       "Kanji": "出す",
       "Definition": "to put out, to send"
     },
     {
-      "Kana": "だんだん",
-      "Kanji": "",
-      "Definition": "gradually, by degrees"
-    },
-    {
+      "ID": "N5#380",
       "Kana": "だれ",
       "Kanji": "誰",
       "Definition": "who"
     },
     {
+      "ID": "N5#381",
       "Kana": "だれか",
       "Kanji": "誰か",
       "Definition": "someone, somebody"
+    },
+    {
+      "ID": "N5#382",
+      "Kana": "だんだん",
+      "Kanji": "",
+      "Definition": "gradually, by degrees"
     }
   ],
   "ち": [
     {
+      "ID": "N5#383",
       "Kana": "ちいさい",
       "Kanji": "小さい",
       "Definition": "small, little"
     },
     {
+      "ID": "N5#384",
       "Kana": "ちいさな",
       "Kanji": "小さな",
       "Definition": "small, little"
     },
     {
+      "ID": "N5#385",
       "Kana": "ちかい",
       "Kanji": "近い",
       "Definition": "near, close by, short"
     },
     {
+      "ID": "N5#386",
       "Kana": "ちがう",
       "Kanji": "違う",
       "Definition": "to differ (from)"
     },
     {
+      "ID": "N5#387",
       "Kana": "ちかく",
       "Kanji": "近く",
       "Definition": "near"
     },
     {
+      "ID": "N5#388",
       "Kana": "ちかてつ",
       "Kanji": "地下鉄",
       "Definition": "underground train, subway"
     },
     {
+      "ID": "N5#389",
       "Kana": "ちず",
       "Kanji": "地図",
       "Definition": "map"
     },
     {
+      "ID": "N5#390",
       "Kana": "ちち",
       "Kanji": "父",
       "Definition": "(one's own) father"
     },
     {
+      "ID": "N5#391",
       "Kana": "ちゃいろ",
       "Kanji": "茶色",
       "Definition": "brown"
     },
     {
+      "ID": "N5#392",
       "Kana": "ちゃわん",
       "Kanji": "",
       "Definition": "rice bowl"
     },
     {
+      "ID": "N5#393",
       "Kana": "ちょうど",
       "Kanji": "",
       "Definition": "just, right, exactly"
     },
     {
+      "ID": "N5#394",
       "Kana": "ちょっと",
       "Kanji": "",
       "Definition": "a little, somewhat"
@@ -2025,61 +2419,73 @@
   ],
   "つ": [
     {
+      "ID": "N5#395",
       "Kana": "ついたち",
       "Kanji": "一日",
       "Definition": "for one day, first of month"
     },
     {
+      "ID": "N5#396",
       "Kana": "つかう",
       "Kanji": "使う",
       "Definition": "to use"
     },
     {
+      "ID": "N5#397",
       "Kana": "つかれる",
       "Kanji": "疲れる",
       "Definition": "to get tired, to tire"
     },
     {
+      "ID": "N5#398",
       "Kana": "つぎ",
       "Kanji": "次",
       "Definition": "next"
     },
     {
+      "ID": "N5#399",
       "Kana": "つく",
       "Kanji": "着く",
       "Definition": "to arrive at, to reach"
     },
     {
+      "ID": "N5#400",
       "Kana": "つくえ",
       "Kanji": "机",
       "Definition": "desk"
     },
     {
+      "ID": "N5#401",
       "Kana": "つくる",
       "Kanji": "作る",
       "Definition": "to make, to create"
     },
     {
+      "ID": "N5#402",
       "Kana": "つける",
       "Kanji": "",
       "Definition": "to turn on (eg a light)"
     },
     {
+      "ID": "N5#403",
       "Kana": "つとめる",
       "Kanji": "勤める",
       "Definition": "to serve, to work (for)"
     },
     {
+      "ID": "N5#404",
       "Kana": "つまらない",
       "Kanji": "",
       "Definition": "insignificant, boring"
     },
     {
+      "ID": "N5#405",
       "Kana": "つめたい",
       "Kanji": "冷たい",
       "Definition": "cold (to the touch)"
     },
     {
+      "ID": "N5#406",
       "Kana": "つよい",
       "Kanji": "強い",
       "Definition": "strong, powerful"
@@ -2087,41 +2493,49 @@
   ],
   "て": [
     {
+      "ID": "N5#407",
       "Kana": "て",
       "Kanji": "手",
       "Definition": "hand"
     },
     {
+      "ID": "N5#408",
       "Kana": "テープ",
       "Kanji": "",
       "Definition": "tape"
     },
     {
+      "ID": "N5#409",
       "Kana": "テープレコーダー",
       "Kanji": "",
       "Definition": "tape recorder"
     },
     {
+      "ID": "N5#410",
       "Kana": "テーブル",
       "Kanji": "",
       "Definition": "table"
     },
     {
+      "ID": "N5#411",
       "Kana": "てがみ",
       "Kanji": "手紙",
       "Definition": "letter"
     },
     {
+      "ID": "N5#412",
       "Kana": "テスト",
       "Kanji": "",
       "Definition": "test"
     },
     {
+      "ID": "N5#413",
       "Kana": "テレビ",
       "Kanji": "",
       "Definition": "television, TV"
     },
     {
+      "ID": "N5#414",
       "Kana": "てんき",
       "Kanji": "天気",
       "Definition": "weather"
@@ -2129,51 +2543,61 @@
   ],
   "で": [
     {
+      "ID": "N5#415",
       "Kana": "でかける",
       "Kanji": "出かける",
       "Definition": "to depart, to go out"
     },
     {
+      "ID": "N5#416",
       "Kana": "できる",
       "Kanji": "",
       "Definition": "to be able to"
     },
     {
+      "ID": "N5#417",
       "Kana": "でぐち",
       "Kanji": "出口",
       "Definition": "exit"
     },
     {
+      "ID": "N5#418",
       "Kana": "では",
       "Kanji": "",
       "Definition": "with that..."
     },
     {
+      "ID": "N5#419",
       "Kana": "デパート",
       "Kanji": "",
       "Definition": "department store"
     },
     {
+      "ID": "N5#420",
       "Kana": "でも",
       "Kanji": "",
       "Definition": "but, however"
     },
     {
+      "ID": "N5#421",
       "Kana": "でる",
       "Kanji": "出る",
       "Definition": "to appear, to leave"
     },
     {
+      "ID": "N5#422",
       "Kana": "でんき",
       "Kanji": "電気",
       "Definition": "electricity, (electric) light"
     },
     {
+      "ID": "N5#423",
       "Kana": "でんしゃ",
       "Kanji": "電車",
       "Definition": "electric train"
     },
     {
+      "ID": "N5#424",
       "Kana": "でんわ",
       "Kanji": "電話",
       "Definition": "telephone"
@@ -2181,96 +2605,115 @@
   ],
   "と": [
     {
+      "ID": "N5#425",
       "Kana": "と",
       "Kanji": "戸",
       "Definition": "door (Japanese style)"
     },
     {
+      "ID": "N5#426",
       "Kana": "トイレ",
       "Kanji": "",
       "Definition": "toilet"
     },
     {
+      "ID": "N5#427",
       "Kana": "とお",
       "Kanji": "十",
       "Definition": "ten"
     },
     {
+      "ID": "N5#428",
       "Kana": "とおい",
       "Kanji": "遠い",
       "Definition": "far, distant"
     },
     {
+      "ID": "N5#429",
       "Kana": "とおか",
       "Kanji": "十日",
       "Definition": "ten days, the tenth (day of the month)"
     },
     {
+      "ID": "N5#430",
       "Kana": "ときどき",
       "Kanji": "時々",
       "Definition": "sometimes"
     },
     {
+      "ID": "N5#431",
       "Kana": "とけい",
       "Kanji": "時計",
       "Definition": "watch, clock"
     },
     {
+      "ID": "N5#432",
       "Kana": "ところ",
       "Kanji": "所",
       "Definition": "place"
     },
     {
+      "ID": "N5#433",
       "Kana": "とし",
       "Kanji": "年",
       "Definition": "year, age"
     },
     {
+      "ID": "N5#434",
       "Kana": "としょかん",
       "Kanji": "図書館",
       "Definition": "library"
     },
     {
+      "ID": "N5#435",
       "Kana": "とても",
       "Kanji": "",
       "Definition": "very"
     },
     {
+      "ID": "N5#436",
       "Kana": "となり",
       "Kanji": "隣",
       "Definition": "next to, next door to"
     },
     {
+      "ID": "N5#437",
       "Kana": "とぶ",
       "Kanji": "飛ぶ",
       "Definition": "to fly, to hop"
     },
     {
+      "ID": "N5#438",
       "Kana": "とまる",
       "Kanji": "止まる",
       "Definition": "to come to a halt"
     },
     {
+      "ID": "N5#439",
       "Kana": "ともだち",
       "Kanji": "友達",
       "Definition": "friend"
     },
     {
+      "ID": "N5#440",
       "Kana": "とり",
       "Kanji": "鳥",
       "Definition": "bird"
     },
     {
+      "ID": "N5#441",
       "Kana": "とりにく",
       "Kanji": "とり肉",
       "Definition": "chicken meat"
     },
     {
+      "ID": "N5#442",
       "Kana": "とる",
       "Kanji": "取る",
       "Definition": "to take"
     },
     {
+      "ID": "N5#443",
       "Kana": "とる",
       "Kanji": "撮る",
       "Definition": "to take (a photo)"
@@ -2278,71 +2721,85 @@
   ],
   "ど": [
     {
+      "ID": "N5#444",
       "Kana": "ドア",
       "Kanji": "",
       "Definition": "door (Western style)"
     },
     {
+      "ID": "N5#445",
       "Kana": "どう",
       "Kanji": "",
       "Definition": "how, in what way"
     },
     {
+      "ID": "N5#446",
       "Kana": "どうして",
       "Kanji": "",
       "Definition": "why?, for what reason"
     },
     {
+      "ID": "N5#447",
       "Kana": "どうぞ",
       "Kanji": "",
       "Definition": "please, kindly, by all means"
     },
     {
+      "ID": "N5#448",
       "Kana": "どうぶつ",
       "Kanji": "動物",
       "Definition": "animal"
     },
     {
+      "ID": "N5#449",
       "Kana": "どうも",
       "Kanji": "",
       "Definition": "thanks, very"
     },
     {
+      "ID": "N5#450",
       "Kana": "どこ",
       "Kanji": "",
       "Definition": "where, what place"
     },
     {
+      "ID": "N5#451",
       "Kana": "どちら",
       "Kanji": "",
       "Definition": "which, which way"
     },
     {
+      "ID": "N5#452",
       "Kana": "どっち",
       "Kanji": "",
       "Definition": "which one, which way"
     },
     {
+      "ID": "N5#453",
       "Kana": "どなた",
       "Kanji": "",
       "Definition": "who"
     },
     {
+      "ID": "N5#454",
       "Kana": "どの",
       "Kanji": "",
       "Definition": "which"
     },
     {
+      "ID": "N5#455",
       "Kana": "どようび",
       "Kanji": "土曜日",
       "Definition": "Saturday"
     },
     {
+      "ID": "N5#456",
       "Kana": "どれ",
       "Kanji": "",
       "Definition": "which (of three or more)"
     },
     {
+      "ID": "N5#457",
       "Kana": "どんな",
       "Kanji": "",
       "Definition": "what, what kind of"
@@ -2350,86 +2807,103 @@
   ],
   "な": [
     {
+      "ID": "N5#458",
       "Kana": "ない",
       "Kanji": "",
       "Definition": "there isn't, doesn't have"
     },
     {
+      "ID": "N5#459",
       "Kana": "ナイフ",
       "Kanji": "",
       "Definition": "knife"
     },
     {
+      "ID": "N5#460",
       "Kana": "なか",
       "Kanji": "中",
       "Definition": "inside, middle, among"
     },
     {
+      "ID": "N5#461",
       "Kana": "ながい",
       "Kanji": "長い",
       "Definition": "long"
     },
     {
+      "ID": "N5#462",
       "Kana": "なく",
       "Kanji": "鳴く",
       "Definition": "to sing (bird), to make sound (animal)"
     },
     {
+      "ID": "N5#463",
       "Kana": "なくす",
       "Kanji": "無くす",
       "Definition": "to lose something"
     },
     {
+      "ID": "N5#464",
       "Kana": "なぜ",
       "Kanji": "",
       "Definition": "why"
     },
     {
+      "ID": "N5#465",
       "Kana": "なつ",
       "Kanji": "夏",
       "Definition": "summer"
     },
     {
+      "ID": "N5#466",
       "Kana": "なつやすみ",
       "Kanji": "夏休み",
       "Definition": "summer vacation, summer holiday"
     },
     {
+      "ID": "N5#467",
       "Kana": "ななつ",
       "Kanji": "七つ",
       "Definition": "seven"
     },
     {
+      "ID": "N5#468",
       "Kana": "なに",
       "Kanji": "何",
       "Definition": "what"
     },
     {
+      "ID": "N5#469",
       "Kana": "なのか",
       "Kanji": "七日",
       "Definition": "seven days, the seventh day (of the month)"
     },
     {
+      "ID": "N5#470",
       "Kana": "なまえ",
       "Kanji": "名前",
       "Definition": "name"
     },
     {
+      "ID": "N5#471",
       "Kana": "ならう",
       "Kanji": "習う",
       "Definition": "to learn"
     },
     {
+      "ID": "N5#472",
       "Kana": "ならぶ",
       "Kanji": "並ぶ",
       "Definition": "to line up, to stand in a line"
     },
     {
+      "ID": "N5#473",
       "Kana": "ならべる",
       "Kanji": "並べる",
       "Definition": "to line up, to set up"
     },
     {
+      "ID": "N5#474",
       "Kana": "なる",
       "Kanji": "",
       "Definition": "to become"
@@ -2437,41 +2911,49 @@
   ],
   "に": [
     {
+      "ID": "N5#475",
       "Kana": "に",
       "Kanji": "二",
       "Definition": "two"
     },
     {
+      "ID": "N5#476",
       "Kana": "にぎやか",
       "Kanji": "",
       "Definition": "bustling, busy"
     },
     {
+      "ID": "N5#477",
       "Kana": "にく",
       "Kanji": "肉",
       "Definition": "meat"
     },
     {
+      "ID": "N5#478",
       "Kana": "にし",
       "Kanji": "西",
       "Definition": "west"
     },
     {
+      "ID": "N5#479",
       "Kana": "にちようび",
       "Kanji": "日曜日",
       "Definition": "Sunday"
     },
     {
+      "ID": "N5#480",
       "Kana": "にもつ",
       "Kanji": "荷物",
       "Definition": "luggage"
     },
     {
+      "ID": "N5#481",
       "Kana": "ニュース",
       "Kanji": "",
       "Definition": "news"
     },
     {
+      "ID": "N5#482",
       "Kana": "にわ",
       "Kanji": "庭",
       "Definition": "garden"
@@ -2479,11 +2961,13 @@
   ],
   "ぬ": [
     {
+      "ID": "N5#483",
       "Kana": "ぬぐ",
       "Kanji": "脱ぐ",
       "Definition": "to take off clothes"
     },
     {
+      "ID": "N5#484",
       "Kana": "ぬるい",
       "Kanji": "温い",
       "Definition": "lukewarm"
@@ -2491,16 +2975,19 @@
   ],
   "ね": [
     {
+      "ID": "N5#485",
       "Kana": "ネクタイ",
       "Kanji": "",
       "Definition": "tie, necktie"
     },
     {
+      "ID": "N5#486",
       "Kana": "ねこ",
       "Kanji": "猫",
       "Definition": "cat"
     },
     {
+      "ID": "N5#487",
       "Kana": "ねる",
       "Kanji": "寝る",
       "Definition": "to go to bed, to sleep"
@@ -2508,26 +2995,31 @@
   ],
   "の": [
     {
+      "ID": "N5#488",
       "Kana": "ノート",
       "Kanji": "",
       "Definition": "notebook, exercise book"
     },
     {
+      "ID": "N5#489",
       "Kana": "のぼる",
       "Kanji": "登る",
       "Definition": "to climb"
     },
     {
+      "ID": "N5#490",
       "Kana": "のみもの",
       "Kanji": "飲み物",
       "Definition": "drink, beverage"
     },
     {
+      "ID": "N5#491",
       "Kana": "のむ",
       "Kanji": "飲む",
       "Definition": "to drink"
     },
     {
+      "ID": "N5#492",
       "Kana": "のる",
       "Kanji": "乗る",
       "Definition": "to get on, to ride in, to board"
@@ -2535,156 +3027,187 @@
   ],
   "は": [
     {
+      "ID": "N5#493",
       "Kana": "は",
       "Kanji": "歯",
       "Definition": "tooth"
     },
     {
+      "ID": "N5#494",
       "Kana": "はい",
       "Kanji": "",
       "Definition": "yes"
     },
     {
+      "ID": "N5#495",
       "Kana": "はいざら",
       "Kanji": "灰皿",
       "Definition": "ashtray"
     },
     {
+      "ID": "N5#496",
       "Kana": "はいる",
       "Kanji": "入る",
       "Definition": "to enter, to contain, to hold"
     },
     {
+      "ID": "N5#497",
       "Kana": "はがき",
       "Kanji": "葉書",
       "Definition": "postcard"
     },
     {
+      "ID": "N5#498",
       "Kana": "はく",
       "Kanji": "",
       "Definition": "to wear, to put on (trousers)"
     },
     {
+      "ID": "N5#499",
       "Kana": "はこ",
       "Kanji": "箱",
       "Definition": "box"
     },
     {
+      "ID": "N5#500",
       "Kana": "はし",
       "Kanji": "橋",
       "Definition": "bridge"
     },
     {
+      "ID": "N5#501",
       "Kana": "はし",
       "Kanji": "",
       "Definition": "chopsticks"
     },
     {
+      "ID": "N5#502",
       "Kana": "はじまる",
       "Kanji": "始まる",
       "Definition": "to begin"
     },
     {
+      "ID": "N5#503",
       "Kana": "はじめ",
       "Kanji": "初め/始め",
       "Definition": "beginning, start"
     },
     {
+      "ID": "N5#504",
       "Kana": "はじめて",
       "Kanji": "初めて",
       "Definition": "for the first time"
     },
     {
+      "ID": "N5#505",
       "Kana": "はしる",
       "Kanji": "走る",
       "Definition": "to run"
     },
     {
+      "ID": "N5#506",
       "Kana": "はたち",
       "Kanji": "二十歳",
       "Definition": "20 years old, 20th year"
     },
     {
+      "ID": "N5#507",
       "Kana": "はたらく",
       "Kanji": "働く",
       "Definition": "to work"
     },
     {
+      "ID": "N5#508",
       "Kana": "はち",
       "Kanji": "八",
       "Definition": "eight"
     },
     {
+      "ID": "N5#509",
       "Kana": "はつか",
       "Kanji": "二十日",
       "Definition": "twenty days, twentieth (day of the month)"
     },
     {
+      "ID": "N5#510",
       "Kana": "はな",
       "Kanji": "花",
       "Definition": "flower"
     },
     {
+      "ID": "N5#511",
       "Kana": "はな",
       "Kanji": "鼻",
       "Definition": "nose"
     },
     {
+      "ID": "N5#512",
       "Kana": "はなし",
       "Kanji": "話",
       "Definition": "talk, story"
     },
     {
+      "ID": "N5#513",
       "Kana": "はなす",
       "Kanji": "話す",
       "Definition": "to speak"
     },
     {
+      "ID": "N5#514",
       "Kana": "はは",
       "Kanji": "母",
       "Definition": "(one's own) mother"
     },
     {
+      "ID": "N5#515",
       "Kana": "はやい",
       "Kanji": "早い",
       "Definition": "early"
     },
     {
+      "ID": "N5#516",
       "Kana": "はやい",
       "Kanji": "速い",
       "Definition": "quick, fast"
     },
     {
+      "ID": "N5#517",
       "Kana": "はる",
       "Kanji": "春",
       "Definition": "spring"
     },
     {
+      "ID": "N5#518",
       "Kana": "はる",
       "Kanji": "貼る",
       "Definition": "to stick, to paste"
     },
     {
+      "ID": "N5#519",
       "Kana": "はれ",
       "Kanji": "晴れ",
       "Definition": "clear weather"
     },
     {
+      "ID": "N5#520",
       "Kana": "はれる",
       "Kanji": "晴れる",
       "Definition": "to be sunny"
     },
     {
+      "ID": "N5#521",
       "Kana": "はん",
       "Kanji": "半",
       "Definition": "half"
     },
     {
+      "ID": "N5#522",
       "Kana": "ハンカチ",
       "Kanji": "",
       "Definition": "handkerchief"
     },
     {
+      "ID": "N5#523",
       "Kana": "はんぶん",
       "Kanji": "半分",
       "Definition": "half"
@@ -2692,26 +3215,31 @@
   ],
   "ば": [
     {
+      "ID": "N5#524",
       "Kana": "バス",
       "Kanji": "",
       "Definition": "bus"
     },
     {
+      "ID": "N5#525",
       "Kana": "バター",
       "Kanji": "",
       "Definition": "butter"
     },
     {
+      "ID": "N5#526",
       "Kana": "ばん",
       "Kanji": "晩",
       "Definition": "evening"
     },
     {
+      "ID": "N5#527",
       "Kana": "ばんごう",
       "Kanji": "番号",
       "Definition": "number"
     },
     {
+      "ID": "N5#528",
       "Kana": "ばんごはん",
       "Kanji": "晩御飯",
       "Definition": "dinner, evening meal"
@@ -2719,11 +3247,13 @@
   ],
   "ぱ": [
     {
+      "ID": "N5#529",
       "Kana": "パーティー",
       "Kanji": "",
       "Definition": "party"
     },
     {
+      "ID": "N5#530",
       "Kana": "パン",
       "Kanji": "",
       "Definition": "bread"
@@ -2731,81 +3261,97 @@
   ],
   "ひ": [
     {
+      "ID": "N5#531",
       "Kana": "ひがし",
       "Kanji": "東",
       "Definition": "east"
     },
     {
+      "ID": "N5#532",
       "Kana": "ひく",
       "Kanji": "引く",
       "Definition": "to pull"
     },
     {
+      "ID": "N5#533",
       "Kana": "ひく",
       "Kanji": "弾く",
       "Definition": "to play (piano, guitar)"
     },
     {
+      "ID": "N5#534",
       "Kana": "ひくい",
       "Kanji": "低い",
       "Definition": "short, low"
     },
     {
+      "ID": "N5#535",
       "Kana": "ひこうき",
       "Kanji": "飛行機",
       "Definition": "aeroplane, airplane"
     },
     {
+      "ID": "N5#536",
       "Kana": "ひだり",
       "Kanji": "左",
       "Definition": "left hand side"
     },
     {
+      "ID": "N5#537",
       "Kana": "ひと",
       "Kanji": "人",
       "Definition": "man, person"
     },
     {
+      "ID": "N5#538",
       "Kana": "ひとつ",
       "Kanji": "一つ",
       "Definition": "one"
     },
     {
+      "ID": "N5#539",
       "Kana": "ひとつき",
       "Kanji": "一月",
       "Definition": "one month"
     },
     {
+      "ID": "N5#540",
       "Kana": "ひとり",
       "Kanji": "一人",
       "Definition": "one person"
     },
     {
+      "ID": "N5#541",
       "Kana": "ひま",
       "Kanji": "暇",
       "Definition": "free time, leisure"
     },
     {
+      "ID": "N5#542",
       "Kana": "ひゃく",
       "Kanji": "百",
       "Definition": "100, hundred"
     },
     {
+      "ID": "N5#543",
       "Kana": "ひらがな",
       "Kanji": "平仮名",
       "Definition": "hiragana"
     },
     {
+      "ID": "N5#544",
       "Kana": "ひる",
       "Kanji": "昼",
       "Definition": "noon, daytime"
     },
     {
+      "ID": "N5#545",
       "Kana": "ひるごはん",
       "Kanji": "昼御飯",
       "Definition": "lunch, midday meal"
     },
     {
+      "ID": "N5#546",
       "Kana": "ひろい",
       "Kanji": "広い",
       "Definition": "spacious, wide"
@@ -2813,11 +3359,13 @@
   ],
   "び": [
     {
+      "ID": "N5#547",
       "Kana": "びょういん",
       "Kanji": "病院",
       "Definition": "hospital"
     },
     {
+      "ID": "N5#548",
       "Kana": "びょうき",
       "Kanji": "病気",
       "Definition": "illness, disease, sickness"
@@ -2825,66 +3373,79 @@
   ],
   "ふ": [
     {
+      "ID": "N5#549",
       "Kana": "フィルム",
       "Kanji": "",
       "Definition": "film (roll of)"
     },
     {
+      "ID": "N5#550",
       "Kana": "ふうとう",
       "Kanji": "封筒",
       "Definition": "envelope"
     },
     {
+      "ID": "N5#551",
       "Kana": "フォーク",
       "Kanji": "",
       "Definition": "fork"
     },
     {
+      "ID": "N5#552",
       "Kana": "ふく",
       "Kanji": "吹く",
       "Definition": "to blow (wind, etc)"
     },
     {
+      "ID": "N5#553",
       "Kana": "ふく",
       "Kanji": "服",
       "Definition": "clothes"
     },
     {
+      "ID": "N5#554",
       "Kana": "ふたつ",
       "Kanji": "二つ",
       "Definition": "two"
     },
     {
+      "ID": "N5#555",
       "Kana": "ふたり",
       "Kanji": "二人",
       "Definition": "two people"
     },
     {
+      "ID": "N5#556",
       "Kana": "ふつか",
       "Kanji": "二日",
       "Definition": "second day of the month, two days"
     },
     {
+      "ID": "N5#557",
       "Kana": "ふとい",
       "Kanji": "太い",
       "Definition": "fat, thick"
     },
     {
+      "ID": "N5#558",
       "Kana": "ふゆ",
       "Kanji": "冬",
       "Definition": "winter"
     },
     {
+      "ID": "N5#559",
       "Kana": "ふる",
       "Kanji": "降る",
       "Definition": "to precipitate, to fall (e.g. rain)"
     },
     {
+      "ID": "N5#560",
       "Kana": "ふるい",
       "Kanji": "古い",
       "Definition": "old (not person), aged, ancient"
     },
     {
+      "ID": "N5#561",
       "Kana": "ふろ",
       "Kanji": "",
       "Definition": "bath"
@@ -2892,11 +3453,13 @@
   ],
   "ぶ": [
     {
+      "ID": "N5#562",
       "Kana": "ぶたにく",
       "Kanji": "豚肉",
       "Definition": "pork"
     },
     {
+      "ID": "N5#563",
       "Kana": "ぶんしょう",
       "Kanji": "文章",
       "Definition": "sentence, text"
@@ -2904,6 +3467,7 @@
   ],
   "ぷ": [
     {
+      "ID": "N5#564",
       "Kana": "プール",
       "Kanji": "",
       "Definition": "swimming pool"
@@ -2911,16 +3475,19 @@
   ],
   "へ": [
     {
+      "ID": "N5#565",
       "Kana": "へた",
       "Kanji": "下手",
       "Definition": "unskillful, poor"
     },
     {
+      "ID": "N5#566",
       "Kana": "へや",
       "Kanji": "部屋",
       "Definition": "room"
     },
     {
+      "ID": "N5#567",
       "Kana": "へん",
       "Kanji": "辺",
       "Definition": "area, vicinity"
@@ -2928,21 +3495,25 @@
   ],
   "べ": [
     {
+      "ID": "N5#568",
       "Kana": "ベッド",
       "Kanji": "",
       "Definition": "bed"
     },
     {
+      "ID": "N5#569",
       "Kana": "べんきょう",
       "Kanji": "勉強",
       "Definition": "studying, diligence"
     },
     {
+      "ID": "N5#570",
       "Kana": "べんきょうする",
       "Kanji": "勉強する",
       "Definition": "to study, be diligent"
     },
     {
+      "ID": "N5#571",
       "Kana": "べんり",
       "Kanji": "便利",
       "Definition": "convenient, handy"
@@ -2950,58 +3521,69 @@
   ],
   "ぺ": [
     {
+      "ID": "N5#572",
       "Kana": "ページ",
       "Kanji": "",
       "Definition": "page"
     },
     {
-      "Kana": "ペット",
-      "Kanji": "",
-      "Definition": "pet"
-    },
-    {
+      "ID": "N5#573",
       "Kana": "ペン",
       "Kanji": "",
       "Definition": "pen"
+    },
+    {
+      "ID": "N5#574",
+      "Kana": "ペット",
+      "Kanji": "",
+      "Definition": "pet"
     }
   ],
   "ほ": [
     {
+      "ID": "N5#575",
       "Kana": "ほう",
       "Kanji": "",
       "Definition": "way"
     },
     {
+      "ID": "N5#576",
       "Kana": "ほか",
       "Kanji": "外",
       "Definition": "other place, the rest"
     },
     {
+      "ID": "N5#577",
       "Kana": "ほしい",
       "Kanji": "欲しい",
       "Definition": "want, in need of, desire"
     },
     {
+      "ID": "N5#578",
       "Kana": "ほそい",
       "Kanji": "細い",
       "Definition": "thin, slender, fine"
     },
     {
+      "ID": "N5#579",
       "Kana": "ホテル",
       "Kanji": "",
       "Definition": "hotel"
     },
     {
+      "ID": "N5#580",
       "Kana": "ほん",
       "Kanji": "本",
       "Definition": "book"
     },
     {
+      "ID": "N5#581",
       "Kana": "ほんだな",
       "Kanji": "本棚",
       "Definition": "bookshelves"
     },
     {
+      "ID": "N5#582",
       "Kana": "ほんとう",
       "Kanji": "",
       "Definition": "reality, truth"
@@ -3009,16 +3591,19 @@
   ],
   "ぼ": [
     {
+      "ID": "N5#583",
       "Kana": "ぼうし",
       "Kanji": "帽子",
       "Definition": "hat"
     },
     {
+      "ID": "N5#584",
       "Kana": "ボールペン",
       "Kanji": "",
       "Definition": "ball-point pen"
     },
     {
+      "ID": "N5#585",
       "Kana": "ボタン",
       "Kanji": "",
       "Definition": "button"
@@ -3026,11 +3611,13 @@
   ],
   "ぽ": [
     {
+      "ID": "N5#586",
       "Kana": "ポケット",
       "Kanji": "",
       "Definition": "pocket"
     },
     {
+      "ID": "N5#587",
       "Kana": "ポスト",
       "Kanji": "",
       "Definition": "post"
@@ -3038,106 +3625,127 @@
   ],
   "ま": [
     {
+      "ID": "N5#588",
       "Kana": "まいあさ",
       "Kanji": "毎朝",
       "Definition": "every morning"
     },
     {
+      "ID": "N5#589",
       "Kana": "まいげつ",
       "Kanji": "毎月",
       "Definition": "every month, monthly"
     },
     {
+      "ID": "N5#590",
       "Kana": "まいしゅう",
       "Kanji": "毎週",
       "Definition": "every week"
     },
     {
+      "ID": "N5#591",
       "Kana": "まいつき",
       "Kanji": "毎月",
       "Definition": "every month, monthly"
     },
     {
+      "ID": "N5#592",
       "Kana": "まいとし",
       "Kanji": "毎年",
       "Definition": "every year, annually"
     },
     {
+      "ID": "N5#593",
       "Kana": "まいにち",
       "Kanji": "毎日",
       "Definition": "every day"
     },
     {
+      "ID": "N5#594",
       "Kana": "まいねん",
       "Kanji": "毎年",
       "Definition": "every year, annually"
     },
     {
+      "ID": "N5#595",
       "Kana": "まいばん",
       "Kanji": "毎晩",
       "Definition": "every night"
     },
     {
+      "ID": "N5#596",
       "Kana": "まえ",
       "Kanji": "前",
       "Definition": "before, in front"
     },
     {
+      "ID": "N5#597",
       "Kana": "まがる",
       "Kanji": "曲る",
       "Definition": "to turn, to bend"
     },
     {
+      "ID": "N5#598",
       "Kana": "まずい",
       "Kanji": "",
       "Definition": "unappetising, unpleasant (taste)"
     },
     {
+      "ID": "N5#599",
       "Kana": "また",
       "Kanji": "",
       "Definition": "again, and"
     },
     {
+      "ID": "N5#600",
       "Kana": "まだ",
       "Kanji": "",
       "Definition": "yet, still, besides"
     },
     {
+      "ID": "N5#601",
       "Kana": "まち",
       "Kanji": "町",
       "Definition": "town, city"
     },
     {
+      "ID": "N5#602",
       "Kana": "まつ",
       "Kanji": "待つ",
       "Definition": "to wait"
     },
     {
+      "ID": "N5#603",
       "Kana": "まっすぐ",
       "Kanji": "",
       "Definition": "straight (ahead), direct"
     },
     {
+      "ID": "N5#604",
       "Kana": "マッチ",
       "Kanji": "",
       "Definition": "match"
     },
     {
+      "ID": "N5#605",
       "Kana": "まど",
       "Kanji": "窓",
       "Definition": "window"
     },
     {
+      "ID": "N5#606",
       "Kana": "まるい",
       "Kanji": "丸い/円い",
       "Definition": "round, circular"
     },
     {
+      "ID": "N5#607",
       "Kana": "まん",
       "Kanji": "万",
       "Definition": "ten thousand, everything"
     },
     {
+      "ID": "N5#608",
       "Kana": "まんねんひつ",
       "Kanji": "万年筆",
       "Definition": "fountain pen"
@@ -3145,76 +3753,91 @@
   ],
   "み": [
     {
+      "ID": "N5#609",
       "Kana": "みがく",
       "Kanji": "磨く",
       "Definition": "to brush (teeth)"
     },
     {
+      "ID": "N5#610",
       "Kana": "みぎ",
       "Kanji": "右",
       "Definition": "right hand side"
     },
     {
+      "ID": "N5#611",
       "Kana": "みじかい",
       "Kanji": "短い",
       "Definition": "short"
     },
     {
+      "ID": "N5#612",
       "Kana": "みず",
       "Kanji": "水",
       "Definition": "water"
     },
     {
+      "ID": "N5#613",
       "Kana": "みせ",
       "Kanji": "店",
       "Definition": "store, shop, establishment"
     },
     {
+      "ID": "N5#614",
       "Kana": "みせる",
       "Kanji": "見せる",
       "Definition": "to show, to display"
     },
     {
+      "ID": "N5#615",
       "Kana": "みち",
       "Kanji": "道",
       "Definition": "road, street"
     },
     {
+      "ID": "N5#616",
       "Kana": "みっか",
       "Kanji": "三日",
       "Definition": "three days, the third day (of the month)"
     },
     {
+      "ID": "N5#617",
       "Kana": "みっつ",
       "Kanji": "三つ",
       "Definition": "three"
     },
     {
+      "ID": "N5#618",
       "Kana": "みどり",
       "Kanji": "緑",
       "Definition": "green"
     },
     {
+      "ID": "N5#619",
       "Kana": "みなさん",
       "Kanji": "皆さん",
       "Definition": "everyone"
     },
     {
+      "ID": "N5#620",
       "Kana": "みなみ",
       "Kanji": "南",
       "Definition": "South, proceeding south"
     },
     {
+      "ID": "N5#621",
       "Kana": "みみ",
       "Kanji": "耳",
       "Definition": "ear"
     },
     {
+      "ID": "N5#622",
       "Kana": "みる",
       "Kanji": "見る",
       "Definition": "to see, to watch"
     },
     {
+      "ID": "N5#623",
       "Kana": "みんな",
       "Kanji": "",
       "Definition": "all, everyone, everybody"
@@ -3222,26 +3845,31 @@
   ],
   "む": [
     {
+      "ID": "N5#624",
       "Kana": "むいか",
       "Kanji": "六日",
       "Definition": "six days, sixth (day of month)"
     },
     {
+      "ID": "N5#625",
       "Kana": "むこう",
       "Kanji": "向こう",
       "Definition": "beyond, over there"
     },
     {
+      "ID": "N5#626",
       "Kana": "むずかしい",
       "Kanji": "難しい",
       "Definition": "difficult"
     },
     {
+      "ID": "N5#627",
       "Kana": "むっつ",
       "Kanji": "六つ",
       "Definition": "six"
     },
     {
+      "ID": "N5#628",
       "Kana": "むら",
       "Kanji": "村",
       "Definition": "village"
@@ -3249,16 +3877,19 @@
   ],
   "め": [
     {
+      "ID": "N5#629",
       "Kana": "め",
       "Kanji": "目",
       "Definition": "eye, eyeball"
     },
     {
+      "ID": "N5#630",
       "Kana": "メートル",
       "Kanji": "",
       "Definition": "metre, meter"
     },
     {
+      "ID": "N5#631",
       "Kana": "めがね",
       "Kanji": "眼鏡",
       "Definition": "spectacles, glasses"
@@ -3266,46 +3897,55 @@
   ],
   "も": [
     {
+      "ID": "N5#632",
       "Kana": "もう",
       "Kanji": "",
       "Definition": "already"
     },
     {
+      "ID": "N5#633",
       "Kana": "もう",
       "Kanji": "",
       "Definition": "again"
     },
     {
+      "ID": "N5#634",
       "Kana": "もくようび",
       "Kanji": "木曜日",
       "Definition": "Thursday"
     },
     {
+      "ID": "N5#635",
       "Kana": "もしもし",
       "Kanji": "",
       "Definition": "hello (on phone)"
     },
     {
+      "ID": "N5#636",
       "Kana": "もつ",
       "Kanji": "持つ",
       "Definition": "(1) to hold, to carry, (2) to possess"
     },
     {
+      "ID": "N5#637",
       "Kana": "もっと",
       "Kanji": "",
       "Definition": "more, longer, farther"
     },
     {
+      "ID": "N5#638",
       "Kana": "もの",
       "Kanji": "物",
       "Definition": "thing, object"
     },
     {
+      "ID": "N5#639",
       "Kana": "もん",
       "Kanji": "門",
       "Definition": "gate"
     },
     {
+      "ID": "N5#640",
       "Kana": "もんだい",
       "Kanji": "問題",
       "Definition": "problem, question"
@@ -3313,46 +3953,55 @@
   ],
   "や": [
     {
+      "ID": "N5#641",
       "Kana": "やおや",
       "Kanji": "八百屋",
       "Definition": "greengrocer"
     },
     {
+      "ID": "N5#642",
       "Kana": "やさい",
       "Kanji": "野菜",
       "Definition": "vegetable"
     },
     {
+      "ID": "N5#643",
       "Kana": "やさしい",
       "Kanji": "易しい",
       "Definition": "easy, plain, simple"
     },
     {
+      "ID": "N5#644",
       "Kana": "やすい",
       "Kanji": "安い",
       "Definition": "cheap, inexpensive"
     },
     {
+      "ID": "N5#645",
       "Kana": "やすみ",
       "Kanji": "休み",
       "Definition": "rest, vacation, holiday"
     },
     {
+      "ID": "N5#646",
       "Kana": "やすむ",
       "Kanji": "休む",
       "Definition": "to rest, to have a break, to take a day off"
     },
     {
+      "ID": "N5#647",
       "Kana": "やっつ",
       "Kanji": "八つ",
       "Definition": "eight"
     },
     {
+      "ID": "N5#648",
       "Kana": "やま",
       "Kanji": "山",
       "Definition": "mountain"
     },
     {
+      "ID": "N5#649",
       "Kana": "やる",
       "Kanji": "",
       "Definition": "to do"
@@ -3360,41 +4009,49 @@
   ],
   "ゆ": [
     {
+      "ID": "N5#650",
       "Kana": "ゆうがた",
       "Kanji": "夕方",
       "Definition": "evening"
     },
     {
+      "ID": "N5#651",
       "Kana": "ゆうはん",
       "Kanji": "夕飯",
       "Definition": "dinner"
     },
     {
+      "ID": "N5#652",
       "Kana": "ゆうびんきょく",
       "Kanji": "郵便局",
       "Definition": "post office"
     },
     {
+      "ID": "N5#653",
       "Kana": "ゆうべ",
       "Kanji": "昨夜",
       "Definition": "last night"
     },
     {
+      "ID": "N5#654",
       "Kana": "ゆうめい",
       "Kanji": "有名",
       "Definition": "famous"
     },
     {
+      "ID": "N5#655",
       "Kana": "ゆく",
       "Kanji": "行く",
       "Definition": "to go"
     },
     {
+      "ID": "N5#656",
       "Kana": "ゆき",
       "Kanji": "雪",
       "Definition": "snow"
     },
     {
+      "ID": "N5#657",
       "Kana": "ゆっくり",
       "Kanji": "",
       "Definition": "slowly, at ease"
@@ -3402,56 +4059,67 @@
   ],
   "よ": [
     {
+      "ID": "N5#658",
       "Kana": "ようか",
       "Kanji": "八日",
       "Definition": "eight days, the eighth (day of the month)"
     },
     {
+      "ID": "N5#659",
       "Kana": "ようふく",
       "Kanji": "洋服",
       "Definition": "Western-style clothes"
     },
     {
+      "ID": "N5#660",
       "Kana": "よい",
       "Kanji": "良い",
       "Definition": "good"
     },
     {
+      "ID": "N5#661",
       "Kana": "よく",
       "Kanji": "",
       "Definition": "frequently, often / well, skillfully"
     },
     {
+      "ID": "N5#662",
       "Kana": "よこ",
       "Kanji": "横",
       "Definition": "beside, side, width"
     },
     {
+      "ID": "N5#663",
       "Kana": "よっか",
       "Kanji": "四日",
       "Definition": "(1) 4th day of month, (2) four days"
     },
     {
+      "ID": "N5#664",
       "Kana": "よっつ",
       "Kanji": "四つ",
       "Definition": "four"
     },
     {
+      "ID": "N5#665",
       "Kana": "よぶ",
       "Kanji": "呼ぶ",
       "Definition": "to call out, to invite"
     },
     {
+      "ID": "N5#666",
       "Kana": "よむ",
       "Kanji": "読む",
       "Definition": "to read"
     },
     {
+      "ID": "N5#667",
       "Kana": "よる",
       "Kanji": "夜",
       "Definition": "evening, night"
     },
     {
+      "ID": "N5#668",
       "Kana": "よわい",
       "Kanji": "弱い",
       "Definition": "weak, feable"
@@ -3459,26 +4127,31 @@
   ],
   "ら": [
     {
+      "ID": "N5#669",
       "Kana": "らいげつ",
       "Kanji": "来月",
       "Definition": "next month"
     },
     {
+      "ID": "N5#670",
       "Kana": "らいしゅう",
       "Kanji": "来週",
       "Definition": "next week"
     },
     {
+      "ID": "N5#671",
       "Kana": "らいねん",
       "Kanji": "来年",
       "Definition": "next year"
     },
     {
+      "ID": "N5#672",
       "Kana": "ラジオ",
       "Kanji": "",
       "Definition": "radio"
     },
     {
+      "ID": "N5#673",
       "Kana": "ラジカセ",
       "Kanji": "",
       "Definition": "radio cassette player"
@@ -3486,59 +4159,69 @@
   ],
   "り": [
     {
+      "ID": "N5#674",
       "Kana": "りっぱ",
       "Kanji": "",
       "Definition": "splendid, fine"
     },
     {
+      "ID": "N5#675",
       "Kana": "りゅうがくせい",
       "Kanji": "留学生",
       "Definition": "overseas student"
     },
     {
+      "ID": "N5#676",
       "Kana": "りょうしん",
       "Kanji": "両親",
       "Definition": "parents, both parents"
     },
     {
+      "ID": "N5#677",
       "Kana": "りょうり",
       "Kanji": "料理",
       "Definition": "cooking, cuisine"
     },
     {
+      "ID": "N5#678",
       "Kana": "りょこう",
       "Kanji": "旅行",
       "Definition": "travel, trip"
     }
   ],
-  "る": [],
   "れ": [
     {
+      "ID": "N5#679",
       "Kana": "れい",
       "Kanji": "零",
       "Definition": "zero, nought"
     },
     {
+      "ID": "N5#680",
       "Kana": "れいぞうこ",
       "Kanji": "冷蔵庫",
       "Definition": "refrigerator"
     },
     {
+      "ID": "N5#681",
       "Kana": "レコード",
       "Kanji": "",
       "Definition": "record"
     },
     {
+      "ID": "N5#682",
       "Kana": "レストラン",
       "Kanji": "",
       "Definition": "restaurant"
     },
     {
+      "ID": "N5#683",
       "Kana": "れんしゅう",
       "Kanji": "練習",
       "Definition": "practice"
     },
     {
+      "ID": "N5#684",
       "Kana": "れんしゅうする",
       "Kanji": "練習する",
       "Definition": "to practice"
@@ -3546,11 +4229,13 @@
   ],
   "ろ": [
     {
+      "ID": "N5#685",
       "Kana": "ろうか",
       "Kanji": "廊下",
       "Definition": "corridor"
     },
     {
+      "ID": "N5#686",
       "Kana": "ろく",
       "Kanji": "六",
       "Definition": "six"
@@ -3558,50 +4243,58 @@
   ],
   "わ": [
     {
+      "ID": "N5#687",
       "Kana": "ワイシャツ",
       "Kanji": "",
       "Definition": "shirt (lit: white shirt), business shirt"
     },
     {
+      "ID": "N5#688",
       "Kana": "わかい",
       "Kanji": "若い",
       "Definition": "young"
     },
     {
+      "ID": "N5#689",
       "Kana": "わかる",
       "Kanji": "分かる",
       "Definition": "to understand"
     },
     {
+      "ID": "N5#690",
       "Kana": "わすれる",
       "Kanji": "忘れる",
       "Definition": "to forget"
     },
     {
+      "ID": "N5#691",
       "Kana": "わたし",
       "Kanji": "私",
       "Definition": "I, myself"
     },
     {
+      "ID": "N5#692",
       "Kana": "わたくし",
       "Kanji": "私",
       "Definition": "I, myself"
     },
     {
+      "ID": "N5#693",
       "Kana": "わたす",
       "Kanji": "渡す",
       "Definition": "to pass over, to hand over"
     },
     {
+      "ID": "N5#694",
       "Kana": "わたる",
       "Kanji": "渡る",
       "Definition": "to cross over, to go across"
     },
     {
+      "ID": "N5#695",
       "Kana": "わるい",
       "Kanji": "悪い",
       "Definition": "bad, inferior"
     }
-  ],
-  "を": []
+  ]
 }


### PR DESCRIPTION
1. Expand vocabulary list with N3 vocabulary (from a different source)
2. Add ids to existing N4 and N5 lists
3. Use session storage to persist compiled list of vocabulary fetched when app loads and grab the untouched list at the beginning of each round
4. Remove used words (as given words) from the local list of vocabulary to prevent being reused and having to look it up in a cache
5. Updated internal Joshi response type to be optional properties bc came across one without a `reading` prop under `japanese` which was surprising