### PR TITLE
Look up words with Joshi API when locally we don't have a fitting match

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,10 +1,10 @@
 "use strict";
 exports.__esModule = true;
-exports.logger = exports.findAndSendMatch = void 0;
+exports.selectWord = exports.logger = exports.formatToEntry = exports.findAndSendMatch = void 0;
 function findAndSendMatch(query, receivedResp, res) {
     for (var i in receivedResp.data) {
         var searchResult = findWord(query, receivedResp.data[i]);
-        console.log("searchResult: ", receivedResp.data[i]);
+        console.log("searchResult: ", searchResult);
         if (searchResult !== undefined) {
             var element = receivedResp.data[i];
             res.send(createFoundResponse(element, searchResult));
@@ -18,7 +18,7 @@ function findWord(query, potentialResult) {
     return potentialResult.japanese.find(function (el) { return matchReading(query, el === null || el === void 0 ? void 0 : el.reading) || matchWord(query, el === null || el === void 0 ? void 0 : el.word); });
 }
 function createFoundResponse(element, searchResult) {
-    var index = element.japanese.findIndex(function (el) { return (el === null || el === void 0 ? void 0 : el.reading.localeCompare(searchResult === null || searchResult === void 0 ? void 0 : searchResult.reading)) === 0 || (el === null || el === void 0 ? void 0 : el.word.localeCompare(searchResult === null || searchResult === void 0 ? void 0 : searchResult.word)) === 0; });
+    var index = element.japanese.findIndex(function (el) { var _a, _b; return ((_a = el === null || el === void 0 ? void 0 : el.reading) === null || _a === void 0 ? void 0 : _a.localeCompare(searchResult === null || searchResult === void 0 ? void 0 : searchResult.reading)) === 0 || ((_b = el === null || el === void 0 ? void 0 : el.word) === null || _b === void 0 ? void 0 : _b.localeCompare(searchResult === null || searchResult === void 0 ? void 0 : searchResult.word)) === 0; });
     var japanese = element.japanese[index];
     var english = element.senses[0].english_definitions;
     var entry = {
@@ -34,6 +34,50 @@ function matchReading(query, reading) {
 function matchWord(query, word) {
     return (word === null || word === void 0 ? void 0 : word.localeCompare(query)) === 0;
 }
+function selectWord(results) {
+    var _a, _b;
+    var n = calcRandomNum(results);
+    for (var index = n; index < results.length; index++) {
+        var word = results[index];
+        if (word.japanese.length
+            && ((_a = word.japanese[0]) === null || _a === void 0 ? void 0 : _a.reading)
+            && isValid(word.japanese[0].reading.substr(-1))) {
+            return word;
+        }
+    }
+    for (var index = 0; index < n; index++) {
+        var word = results[index];
+        if (word.japanese.length
+            && ((_b = word.japanese[0]) === null || _b === void 0 ? void 0 : _b.reading)
+            && isValid(word.japanese[0].reading.substr(-1))) {
+            return word;
+        }
+    }
+    return null;
+}
+exports.selectWord = selectWord;
+function calcRandomNum(arr) {
+    var result = Math.floor(arr.length * Math.random());
+    return result;
+}
+function isValid(char) {
+    var firstCheck = char.localeCompare("ー") !== 0;
+    var secondCheck = char.localeCompare("～") !== 0;
+    var thirdCheck = char.localeCompare("ん") !== 0;
+    var fourthCheck = char.localeCompare("ン") !== 0;
+    return firstCheck && secondCheck && thirdCheck && fourthCheck;
+}
+function formatToEntry(element) {
+    var japanese = element.japanese[0];
+    var english = element.senses[0].english_definitions;
+    var entry = {
+        slug: element.slug,
+        japanese: japanese,
+        english: english
+    };
+    return entry;
+}
+exports.formatToEntry = formatToEntry;
 function logger(req, _, next) {
     if (req.method !== "POST" && req.url !== "/search") {
         console.log(req.method, req.url, req.body);

--- a/server/helpers.ts
+++ b/server/helpers.ts
@@ -30,7 +30,7 @@ interface ApiEntry {
 function findAndSendMatch(query: string, receivedResp: JoshiResponse, res: Response): boolean {
   for (const i in receivedResp.data) {
     const searchResult = findWord(query, receivedResp.data[i]);
-    console.log(`searchResult: `, receivedResp.data[i]);
+    console.log(`searchResult: `, searchResult);
 
     if (searchResult !== undefined) {
       const element = receivedResp.data[i];
@@ -50,7 +50,7 @@ function findWord(query: string, potentialResult: JoshiElement): JapaneseEntry |
 
 function createFoundResponse(element: JoshiElement, searchResult: JapaneseEntry): ApiResponse {
   const index = element.japanese.findIndex(
-    el => el?.reading.localeCompare(searchResult?.reading) === 0 || el?.word.localeCompare(searchResult?.word) === 0
+    el => el?.reading?.localeCompare(searchResult?.reading) === 0 || el?.word?.localeCompare(searchResult?.word) === 0
   );
   const japanese = element.japanese[index];
   const english = element.senses[0].english_definitions;
@@ -69,6 +69,55 @@ function matchWord(query: string, word: string | undefined): boolean {
   return word?.localeCompare(query) === 0;
 }
 
+function selectWord(results: Array<JoshiElement>): JoshiElement | null {
+  const n = calcRandomNum(results);
+  for (let index = n; index < results.length; index++) {
+    const word = results[index];
+    if (
+      word.japanese.length
+      && word.japanese[0]?.reading
+      && isValid(word.japanese[0].reading.substr(-1))
+    ) {
+      return word;
+    }
+  }
+  for (let index = 0; index < n; index++) {
+    const word = results[index];
+    if (
+      word.japanese.length
+      && word.japanese[0]?.reading
+      && isValid(word.japanese[0].reading.substr(-1))
+    ) {
+      return word;
+    }
+  }
+  return null;
+}
+
+function calcRandomNum(arr: Array<any>): number {
+  const result = Math.floor(arr.length * Math.random());
+  return result;
+}
+
+function isValid(char: string) {
+  const firstCheck = char.localeCompare("ー") !== 0;
+  const secondCheck = char.localeCompare("～") !== 0;
+  const thirdCheck = char.localeCompare("ん") !== 0;
+  const fourthCheck = char.localeCompare("ン") !== 0;
+  return firstCheck && secondCheck && thirdCheck && fourthCheck;
+}
+
+function formatToEntry(element: JoshiElement): ApiEntry {
+  const japanese = element.japanese[0];
+  const english = element.senses[0].english_definitions;
+  const entry = {
+    slug: element.slug,
+    japanese,
+    english,
+  }
+  return entry;
+}
+
 function logger(req: Request, _, next: Next) {
   if (req.method !== "POST" && req.url !== "/search") {
     console.log(req.method, req.url, req.body);
@@ -82,5 +131,7 @@ function logger(req: Request, _, next: Next) {
 
 export {
   findAndSendMatch,
+  formatToEntry,
   logger,
+  selectWord,
 }

--- a/server/index.js
+++ b/server/index.js
@@ -30,6 +30,35 @@ app.get("/api/vocabulary/:level", function (req, res) {
         console.error("error:", error);
     }
 });
+app.get("/api/words-starting-with/:character", function (req, res) {
+    var _a;
+    var character = (_a = req.params) === null || _a === void 0 ? void 0 : _a.character;
+    var decodedChar = decodeURI(character);
+    console.log("character: " + decodedChar);
+    node_fetch_1["default"](baseURL + "/words?keyword=" + encodeURI(decodedChar) + "*", {
+        method: "GET",
+        headers: {
+            "Accept": "application/json"
+        }
+    })
+        .then(function (r) { return r.json(); })
+        .then(function (r) {
+        console.log(r);
+        if (r.data.length === 0) {
+            console.log("no data");
+            res.send({ found: false, msg: "No data" });
+            return;
+        }
+        var word = helpers_1.selectWord(r.data);
+        if (!word) {
+            console.log("no word");
+            res.send({ found: false, response: r });
+            return;
+        }
+        console.log("found word", word);
+        res.send({ found: true, entry: helpers_1.formatToEntry(word) });
+    });
+});
 app.post("/api/search", function (req, res) {
     var query = req.body.query || "";
     console.log("query: " + query);
@@ -49,7 +78,6 @@ app.post("/api/search", function (req, res) {
         if (!helpers_1.findAndSendMatch(query, r, res)) {
             res.send({ found: false, response: r });
         }
-        console.log("nothing found");
         res.end();
     });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -43,7 +43,6 @@ app.get("/api/words-starting-with/:character", function (req, res) {
     })
         .then(function (r) { return r.json(); })
         .then(function (r) {
-        console.log(r);
         if (r.data.length === 0) {
             console.log("no data");
             res.send({ found: false, msg: "No data" });
@@ -57,6 +56,9 @@ app.get("/api/words-starting-with/:character", function (req, res) {
         }
         console.log("found word", word);
         res.send({ found: true, entry: helpers_1.formatToEntry(word) });
+    })["catch"](function (error) {
+        console.error(error);
+        res.end();
     });
 });
 app.post("/api/search", function (req, res) {
@@ -79,6 +81,8 @@ app.post("/api/search", function (req, res) {
             res.send({ found: false, response: r });
         }
         res.end();
+    })["catch"](function (error) {
+        console.error(error);
     });
 });
 app.listen(PORT, function () {

--- a/server/index.ts
+++ b/server/index.ts
@@ -55,8 +55,6 @@ app.get("/api/words-starting-with/:character", (req: Request, res: Response) => 
   })
     .then(r => r.json())
     .then(r => {
-      console.log(r);
-
       if (r.data.length === 0) {
         console.log(`no data`);
         res.send({ found: false, msg: "No data" });

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,12 @@ const bodyParser = require('body-parser');
 const express = require('express');
 const fs = require("fs");
 
-import { findAndSendMatch, logger } from "./helpers";
+import {
+  findAndSendMatch,
+  formatToEntry,
+  logger,
+  selectWord,
+} from "./helpers";
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -37,6 +42,43 @@ app.get("/api/vocabulary/:level", (req: Request, res: Response) => {
   }
 });
 
+app.get("/api/words-starting-with/:character", (req: Request, res: Response) => {
+  const character = req.params?.character;
+  const decodedChar = decodeURI(character);
+  console.log(`character: ${decodedChar}`);
+
+  fetch(`${baseURL}/words?keyword=${encodeURI(decodedChar)}*`, {
+    method: "GET",
+    headers: {
+      "Accept": "application/json",
+    }
+  })
+    .then(r => r.json())
+    .then(r => {
+      console.log(r);
+
+      if (r.data.length === 0) {
+        console.log(`no data`);
+        res.send({ found: false, msg: "No data" });
+        return;
+      }
+
+      const word = selectWord(r.data)
+      if (!word) {
+        console.log(`no word`);
+        res.send({ found: false, response: r });
+        return;
+      }
+
+      console.log(`found word`, word);
+      res.send({ found: true, entry: formatToEntry(word) });
+    })
+    .catch(error => {
+      console.error(error);
+      res.end();
+    });
+});
+
 app.post("/api/search", (req: Request, res: Response) => {
   const query = req.body.query || "";
   console.log(`query: ${query}`);
@@ -59,8 +101,10 @@ app.post("/api/search", (req: Request, res: Response) => {
         res.send({ found: false, response: r });
       }
 
-      console.log(`nothing found`);
       res.end();
+    })
+    .catch(error => {
+      console.error(error);
     });
 });
 

--- a/src/scripts/game/game.ts
+++ b/src/scripts/game/game.ts
@@ -45,7 +45,7 @@ export default function Game() {
     }
   }
 
-  function showCorrectUI(): void {
+  async function showCorrectUI(): Promise<void> {
     resultOverlay.classList.add("correct");
     inputEl.classList.add("game-ui__input--correct");
 
@@ -53,17 +53,17 @@ export default function Game() {
     emojiContainer.classList.add("emoji--slideleft");
     emojiHappy.classList.remove("hide");
 
+    await displayWord("next");
     emphasizeWord();
     resetInput();
-    displayWord("next");
     activateTransitions();
   }
 
-  function emphasizeWord() {
+  function emphasizeWord(): void {
     prevWord.classList.add("focus");
     inputEl.parentElement.parentElement.classList.add("hide");
   }
-  function resetWordEmphasis(timeout: number) {
+  function resetWordEmphasis(timeout: number): void {
     if (window.innerWidth < 1024) {
       inputEl.parentElement.parentElement.classList.remove("hide");
       prevWord.classList.remove("focus");
@@ -82,13 +82,13 @@ export default function Game() {
     }, timeout);
   }
 
-  function displayWord(type: "start" | "next") {
-    const nextVocab = type === "start" ? vocabInstance.start() : vocabInstance.nextWord();
+  async function displayWord(type: "start" | "next"): Promise<void> {
+    const nextVocab = type === "start" ? await vocabInstance.start() : await vocabInstance.nextWord();
     prevPrimary.innerText = nextVocab?.Kanji || nextVocab?.Kana;
     prevSecondary.innerText = nextVocab.Kanji ? nextVocab.Kana : "";
   }
 
-  function activateTransitions() {
+  function activateTransitions(): void {
     setTimeout(() => {
       document.body.style.overflowX = "";
       emojiContainer.classList.add("emoji--vanish");
@@ -105,12 +105,12 @@ export default function Game() {
   }
 
   return {
-    initPlay: function () {
+    initPlay: async function (): Promise<void> {
       landingPic.classList.add("fade-out");
       playBtn.classList.add("fade-out");
 
+      await displayWord("start")
       emphasizeWord();
-      displayWord("start")
 
       setTimeout(() => {
         landingPic.remove();
@@ -119,7 +119,7 @@ export default function Game() {
       }, 500);
     },
 
-    initPlayAgain: function () {
+    initPlayAgain: async function (): Promise<void> {
       resultOverlay.classList.remove("wrong");
       underlay.classList.remove("gameover");
       resetInput();
@@ -127,12 +127,12 @@ export default function Game() {
       playAgainBtn.parentElement.classList.remove("play-again--show");
       emojiSad.classList.add("hide");
 
+      await displayWord("start");
       emphasizeWord();
-      displayWord("start");
       resetWordEmphasis(1300);
     },
 
-    searchUsersGuess: async function () {
+    searchUsersGuess: function (): Promise<void> {
       inputEl.disabled = true;
       return vocabInstance.searchUsersGuess(inputEl.value)
         .then(_ => {
@@ -144,7 +144,7 @@ export default function Game() {
         });
     },
 
-    gameover: function () {
+    gameover: function (): void {
       showWrongUI();
     }
   }

--- a/src/scripts/game/index.ts
+++ b/src/scripts/game/index.ts
@@ -19,17 +19,21 @@ export default function InitGame() {
   return {
     addListeners: function () {
 
-      playBtnListener = playBtn.addEventListener("click", _ => {
-        gameInstance.initPlay();
-        clockInstance.countdown();
-        scoreInstance.init();
-        playBtn.removeEventListener("click", playBtnListener);
+      playBtnListener = playBtn.addEventListener("click", async _ => {
+        await gameInstance.initPlay()
+          .then(_ => {
+            clockInstance.countdown();
+            scoreInstance.init();
+            playBtn.removeEventListener("click", playBtnListener);
+          });
       });
 
-      playAgainBtn.addEventListener("click", _ => {
-        gameInstance.initPlayAgain();
-        clockInstance.reset();
-        scoreInstance.reset();
+      playAgainBtn.addEventListener("click", async _ => {
+        await gameInstance.initPlayAgain()
+          .then(_ => {
+            clockInstance.reset();
+            scoreInstance.reset();
+          });
       });
 
       formListener = guessForm.addEventListener("submit", event => {

--- a/src/scripts/game/vocabulary/helpers.ts
+++ b/src/scripts/game/vocabulary/helpers.ts
@@ -9,6 +9,7 @@ import {
   ensureHiragana,
 } from "./helper_atoms";
 import { DebugMode, apiRequest, debug, } from "../../helpers";
+import { HistoryInstance } from "./history";
 
 function searchUsersGuess(currentWord: string, query: string, mode?: DebugMode): Promise<Entry> {
   debug(mode, [`guess`, query]);
@@ -201,6 +202,20 @@ function removeWordFromVocab(selectedWord: Vocabulary, vocab: JSON): JSON {
   return vocab;
 }
 
+async function getNextWord(char: string, history: HistoryInstance): Promise<Entry> {
+  const nextWord = await getWordStartingWith(char);
+
+  if (!nextWord) {
+    return null;
+  }
+
+  if (!history.check(nextWord)) {
+    return await getNextWord(char, history);
+  }
+
+  return nextWord;
+}
+
 async function getWordStartingWith(char: string): Promise<Entry> {
   const response = await apiRequest(`/words-starting-with/${encodeURI(char)}`, { method: "GET" });
 
@@ -228,15 +243,16 @@ export {
   Vocabulary,
   compileVocabulary,
   formatToVocab,
+  getNextWord,
   getRandomChar,
   getVocabulary,
-  getWordStartingWith,
   removeWordFromVocab,
   searchUsersGuess,
   selectWord,
 }
 
 export const Test = {
+  getWordStartingWith,
   isValid,
   startsWithLastChar,
   validateQuery,

--- a/src/scripts/game/vocabulary/helpers.ts
+++ b/src/scripts/game/vocabulary/helpers.ts
@@ -10,7 +10,7 @@ import {
 } from "./helper_atoms";
 import { DebugMode, apiRequest, debug, } from "../../helpers";
 
-async function searchUsersGuess(currentWord: string, query: string, mode?: DebugMode): Promise<Entry> {
+function searchUsersGuess(currentWord: string, query: string, mode?: DebugMode): Promise<Entry> {
   debug(mode, [`guess`, query]);
 
   return validateQuery(currentWord, query)
@@ -32,7 +32,7 @@ async function searchUsersGuess(currentWord: string, query: string, mode?: Debug
 /**
  * Prior to HTTP-request validations
  */
-async function validateQuery(currentWord: string, query: string, mode?: DebugMode): Promise<string> {
+function validateQuery(currentWord: string, query: string, mode?: DebugMode): Promise<string> {
   if (!wanakana.isJapanese(query)) {
     return Promise.reject(Error("Not Japanese"));
   }
@@ -52,7 +52,7 @@ async function validateQuery(currentWord: string, query: string, mode?: DebugMod
 /**
  * Post HTTP-request validations - bc we cannot validate kanji inputs
  */
-async function validateResponse(response: Response, currentWord: string): Promise<string> {
+function validateResponse(response: Response, currentWord: string): Promise<string> {
   if (!response.found) {
     return Promise.reject(Error("No exact matches in the Joshi dictionary"));
   }
@@ -127,7 +127,7 @@ function startsWithLastChar(prevWord: string, guessWord: string, mode?: DebugMod
 }
 
 function selectWord(choices: Array<Vocabulary>, mode?: DebugMode): Vocabulary | null {
-  if (!choices.length) {
+  if (!choices?.length) {
     return null;
   }
 
@@ -166,24 +166,6 @@ function selectWord(choices: Array<Vocabulary>, mode?: DebugMode): Vocabulary | 
   return selectedObj;
 }
 
-/**
- * Chooses a viable character to be used to find a word to be used in the game's next round
- */
-function selectChar(vocab, char: string, mode?: DebugMode): string {
-  char = ensureHiragana(char);
-
-  if (vocab && (!vocab[char] || !vocab[char].length)) {
-    const nextChar = getRandomChar();
-    debug(mode, [`no selection to choose from. trying ${nextChar}`]);
-    // TODO: make call to Joshi for a word, new backend endpoint
-    // https://jisho.org/api/v1/search/words?keyword=た*
-    // https://jisho.org/docs
-    return selectChar(vocab, nextChar);
-  }
-
-  return char;
-}
-
 function getVocabulary(level: number): Promise<JSON> {
   return apiRequest(`/vocabulary/n${level}`, { method: "GET" })
     .then(JSON.parse);
@@ -219,15 +201,38 @@ function removeWordFromVocab(selectedWord: Vocabulary, vocab: JSON): JSON {
   return vocab;
 }
 
+async function getWordStartingWith(char: string): Promise<Entry> {
+  const response = await apiRequest(`/words-starting-with/${encodeURI(char)}`, { method: "GET" });
+
+  if (!response.found) {
+    console.warn(`There are no words starting with ${char} at this time. Another word will be supplied.`);
+    return;
+  }
+
+  return response.entry;
+}
+
+function formatToVocab(entry: Entry): Vocabulary {
+  return {
+    ID: entry.slug,
+    Kana: entry.japanese.reading, // backend enforces the availability of this
+    Kanji: entry.japanese?.word,
+    Definition:
+      entry.english.length
+        ? entry.english.reduce((acc, def) => acc.concat(def), " / ")
+        : "",
+  }
+}
 
 export {
   Vocabulary,
   compileVocabulary,
+  formatToVocab,
   getRandomChar,
   getVocabulary,
+  getWordStartingWith,
   removeWordFromVocab,
   searchUsersGuess,
-  selectChar,
   selectWord,
 }
 

--- a/src/scripts/game/vocabulary/history.ts
+++ b/src/scripts/game/vocabulary/history.ts
@@ -1,10 +1,20 @@
 import { DebugMode, debug } from "../../helpers";
 import { Entry } from "./helper_atoms";
 
+export interface HistoryInstance {
+  check: (entry: Entry) => boolean;
+  add: (entry: Entry) => void;
+  clear: () => void;
+  test: Test;
+}
+interface Test {
+  getEntries: () => Array<[string, any]>;
+}
+
 /**
  * Tracks successful user guesses to prevent duplicates
  */
-export default function History(mode?: DebugMode) {
+export default function History(mode?: DebugMode): HistoryInstance {
   let cache = {};
 
   return {

--- a/src/scripts/game/vocabulary/index.ts
+++ b/src/scripts/game/vocabulary/index.ts
@@ -1,11 +1,11 @@
-import History from "./history";
+import History, { HistoryInstance } from "./history";
 import {
   Vocabulary,
   compileVocabulary,
   formatToVocab,
+  getNextWord,
   getRandomChar,
   getVocabulary,
-  getWordStartingWith,
   removeWordFromVocab,
   searchUsersGuess,
   selectWord,
@@ -72,17 +72,12 @@ export default function Vocab() {
       const selectedObj = selectWord(vocab[nextFirst]);
 
       if (!selectedObj) {
-        let fetchedWord = await getWordStartingWith(nextFirst);
+        const fetchedWord = await getNextWord(nextFirst, history);
 
         if (!fetchedWord) {
           console.log(`An error occurred and a word starting with ${nextFirst} couldn't be found at this time. Another word with another beginning character will be supplied.`);
           return await this.start();
         }
-
-        // TODO: see if user guessed the word yet 
-        // if (!history.check(fetchedWord)) {
-        //   fetchedWord = await getWordStartingWith(nextFirst);
-        // }
 
         history.add(fetchedWord);
         const formattedWord = formatToVocab(fetchedWord);
@@ -98,6 +93,9 @@ export default function Vocab() {
       return selectedObj;
     },
     Test: {
+      getHistory: function (): HistoryInstance {
+        return history;
+      },
       setVocab: function (vocabulary): void {
         vocab = vocabulary;
       },

--- a/src/scripts/helpers.ts
+++ b/src/scripts/helpers.ts
@@ -7,11 +7,15 @@ function get(el): HTMLElement {
 }
 
 function apiRequest(path: string, options): Promise<any> {
-  return fetch(`/api${path}`, {
+  return fetch(`http://localhost:8080/api${path}`, {
     headers: { "Content-Type": "application/json" },
     ...options,
   })
-    .then(res => res.json());
+    .then(res => res.json())
+    .catch(err => {
+      console.error(err);
+      return err;
+    });
 }
 
 function debug(mode: DebugMode = "normal", params: Array<any>) {


### PR DESCRIPTION
1. New endpoint to search for words starting with `x` character from Jisho's API to select the next word
2. Adjust previously sync methods to async to wait for response from backend
3. Unit tests
4. Backend bug fix -- when `word` isn't passed from Joshi, can't call `localeCompare` on undefined
5. Frontend bug fix -- when `vocab` list doesn't have any words for a single hiragana character
6. Prevent warnings about absolute URLs pertaining to `apiRequest` helper's fetch requests