### PR TITLE
Track history of all used words

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -60,7 +60,7 @@ app.get("/api/words-starting-with/:character", (req: Request, res: Response) => 
         res.send({ found: false, msg: "No data" });
         return;
       }
-
+      // TODO: filter 'results' to ensure they actually start with the right character
       const word = selectWord(r.data)
       if (!word) {
         console.log(`no word`);

--- a/src/scripts/game/vocabulary/helper_atoms.ts
+++ b/src/scripts/game/vocabulary/helper_atoms.ts
@@ -138,11 +138,17 @@ function formatToVocab(entry: Entry): Vocabulary {
     ID: entry.slug,
     Kana: entry.japanese.reading, // backend enforces the availability of this
     Kanji: entry.japanese?.word,
-    Definition:
-      entry.english.length
-        ? entry.english.reduce((acc, def) => acc.concat(def), " / ")
-        : "",
+    Definition: formatDefinition(entry),
   }
+}
+function formatDefinition(entry: Entry): string {
+  if (!entry.english.length) {
+    return "";
+  }
+  if (entry.english.length === 1) {
+    return entry.english[0];
+  }
+  return entry.english.reduce((acc, def) => !!def ? acc.concat(` / ${def}`) : acc, "");
 }
 
 function hasPunctuation(word: string): boolean {

--- a/src/scripts/game/vocabulary/helper_atoms.ts
+++ b/src/scripts/game/vocabulary/helper_atoms.ts
@@ -42,8 +42,8 @@ interface Entry {
   english: Array<string>;
 }
 interface Japanese {
-  reading: string;
-  word: string;
+  reading?: string;
+  word?: string;
 }
 
 interface Vocabulary {
@@ -148,7 +148,15 @@ function formatDefinition(entry: Entry): string {
   if (entry.english.length === 1) {
     return entry.english[0];
   }
-  return entry.english.reduce((acc, def) => !!def ? acc.concat(` / ${def}`) : acc, "");
+  return entry.english.reduce((acc, def, index) => {
+    if (index === 0) {
+      return acc.concat(def);
+    }
+    if (!def) {
+      return acc;
+    }
+    return acc.concat(` / ${def}`);
+  }, "");
 }
 
 function hasPunctuation(word: string): boolean {

--- a/src/scripts/game/vocabulary/helpers.ts
+++ b/src/scripts/game/vocabulary/helpers.ts
@@ -24,7 +24,7 @@ function searchUsersGuess(currentWord: string, query: string, mode?: DebugMode):
     })
       .then(r => r.json())
       .then((r: Response) => {
-        debug(mode, [r]);
+        console.debug(r);
 
         if (!r.found) {
           return Promise.reject(Error("No exact matches in the Joshi dictionary"));

--- a/src/scripts/game/vocabulary/history.ts
+++ b/src/scripts/game/vocabulary/history.ts
@@ -1,9 +1,10 @@
 import { DebugMode, debug } from "../../helpers";
-import { Entry } from "./helper_atoms";
+import { Entry, Vocabulary } from "./helper_atoms";
 
 export interface HistoryInstance {
+  confirm: (word: Vocabulary) => boolean;
   check: (entry: Entry) => boolean;
-  add: (entry: Entry) => void;
+  add: (entry: Entry | Vocabulary) => void;
   clear: () => void;
   test: Test;
 }
@@ -12,21 +13,55 @@ interface Test {
 }
 
 /**
- * Tracks successful user guesses to prevent duplicates
+ * Tracks all used words during each round to prevent duplicates by us or the user
  */
 export default function History(mode?: DebugMode): HistoryInstance {
   let cache = {};
 
   return {
     /**
-     * Verifies if user's guess is in the cache or not - T meaning the guess is valid
+     * Verifies if word can be used, if not it's bc user already used it as a guess - T meaning word can be used and user hasn't used it yet
+     */
+    confirm: function (lookupWord: Vocabulary): boolean {
+      console.log(`history confirming`, lookupWord);
+      const cacheValues = Object.values(cache) as Array<Entry | Vocabulary>;
+
+      for (let index = 0; index < cacheValues.length; index++) {
+        const cachedWord = cacheValues[index];
+
+        if (isVocabulary(cachedWord)) {
+          if (matchById(lookupWord, cachedWord)) {
+            return false;
+          }
+        }
+
+        if (isEntry(cachedWord)) {
+          if (
+            matchByKanji(lookupWord, cachedWord)
+            || matchByReading(lookupWord, cachedWord)
+          ) {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    },
+    /**
+     * Verifies if user's guess is valid - T meaning valid and user hasn't used it yet
      */
     check: function (entry: Entry): boolean {
       debug(mode, [`history check`, !cache[entry.slug]]);
       return !cache[entry.slug];
     },
-    add: function (entry: Entry): void {
-      cache[entry.slug] = entry;
+    add: function (wordObj: Entry | Vocabulary): void {
+      if (isEntry(wordObj)) {
+        cache[wordObj["slug"]] = wordObj;
+        debug(mode, [`history after add`, cache]);
+        return;
+      }
+
+      cache[wordObj.ID] = wordObj;
       debug(mode, [`history after add`, cache]);
     },
     clear: function (): void {
@@ -39,4 +74,22 @@ export default function History(mode?: DebugMode): HistoryInstance {
       }
     }
   };
+}
+
+function isEntry(wordObj: Entry | Vocabulary): wordObj is Entry {
+  return (wordObj as Entry).slug !== undefined;
+}
+function isVocabulary(wordObj: Entry | Vocabulary): wordObj is Vocabulary {
+  return (wordObj as Vocabulary).ID !== undefined;
+}
+
+function matchById(lookupWord: Vocabulary, cachedWord: Vocabulary): boolean {
+  return lookupWord.ID.localeCompare(cachedWord.ID) === 0;
+}
+function matchByKanji(lookupWord: Vocabulary, cachedWord: Entry): boolean {
+  return lookupWord.Kanji.localeCompare(cachedWord.japanese?.word) === 0;
+}
+function matchByReading(lookupWord: Vocabulary, cachedWord: Entry): boolean {
+  return lookupWord.Kana.localeCompare(cachedWord.japanese?.reading) === 0
+    && (!lookupWord.Kanji.length && !cachedWord.japanese?.word);
 }

--- a/src/scripts/game/vocabulary/index.ts
+++ b/src/scripts/game/vocabulary/index.ts
@@ -52,6 +52,7 @@ export default function Vocab() {
           return Promise.resolve(entry);
         })
         .then(entry => {
+          console.log(`user guess`, entry);
           nextFirst = convertSmallChars(entry?.japanese?.reading || "");
           history.add(entry);
           return Promise.resolve();
@@ -70,11 +71,9 @@ export default function Vocab() {
       return await this.nextWord();
     },
 
-    nextWord: async function (): Promise<Vocabulary> {
+    nextWord: async function nextWord(): Promise<Vocabulary> {
       console.log(`nextWord start ${nextFirst}`);
-
       nextFirst = ensureHiragana(nextFirst);
-      console.log(`nextFirst`, nextFirst);
       const selectedObj = selectWord(vocab[nextFirst]);
 
       if (!selectedObj) {
@@ -92,8 +91,12 @@ export default function Vocab() {
         return formattedWord;
       }
 
-      // history.check() see if next word was already used by user guess
+      if (!history.confirm(selectedObj)) {
+        vocab = removeWordFromVocab(selectedObj, vocab);
+        return await nextWord();
+      }
 
+      history.add(selectedObj);
       currentWord = selectedObj.Kana;
       console.log(`selected`, selectedObj);
 

--- a/src/scripts/game/vocabulary/index.ts
+++ b/src/scripts/game/vocabulary/index.ts
@@ -52,7 +52,7 @@ export default function Vocab() {
           return Promise.resolve(entry);
         })
         .then(entry => {
-          console.log(`user guess`, entry);
+          console.debug(`user guess`, entry);
           nextFirst = convertSmallChars(entry?.japanese?.reading || "");
           history.add(entry);
           return Promise.resolve();
@@ -66,13 +66,13 @@ export default function Vocab() {
 
     start: async function () {
       vocab = JSON.parse(window.sessionStorage.getItem("vocab"));
-      console.log(`vocab start`);
+      console.debug(`vocab start`);
       nextFirst = getRandomChar();
       return await this.nextWord();
     },
 
     nextWord: async function nextWord(): Promise<Vocabulary> {
-      console.log(`nextWord start ${nextFirst}`);
+      console.debug(`nextWord start ${nextFirst}`);
       nextFirst = ensureHiragana(nextFirst);
       const selectedObj = selectWord(vocab[nextFirst]);
 
@@ -87,18 +87,18 @@ export default function Vocab() {
         history.add(fetchedWord);
         const formattedWord = formatToVocab(fetchedWord);
         currentWord = formattedWord.Kana;
-        console.log(`selected`, formattedWord);
+        console.debug(`selected`, formattedWord);
         return formattedWord;
       }
 
-      if (!history.confirm(selectedObj)) {
+      if (!history.check(selectedObj)) {
         vocab = removeWordFromVocab(selectedObj, vocab);
         return await nextWord();
       }
 
       history.add(selectedObj);
       currentWord = selectedObj.Kana;
-      console.log(`selected`, selectedObj);
+      console.debug(`selected`, selectedObj);
 
       vocab = removeWordFromVocab(selectedObj, vocab);
       return selectedObj;

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -5,7 +5,7 @@ describe("History()", () => {
   describe("add()", () => {
     it("adds the already confirmed entry to the current round's cache", () => {
       const history = History();
-      const beforeCache = history.test.getEntries();
+      const beforeCache = history.Test.getEntries();
       const confirmedEntry = {
         slug: "0",
         japanese: {
@@ -15,46 +15,128 @@ describe("History()", () => {
         english: [],
       };
       history.add(confirmedEntry);
-      const afterCache = history.test.getEntries();
+      const afterCache = history.Test.getEntries();
+      expect(afterCache.length).toBe(beforeCache.length + 1);
+    });
+
+    it("adds a Vocab to the cache", () => {
+      const history = History();
+      const beforeCache = history.Test.getEntries();
+      const vocab = {
+        ID: "1",
+        Kana: "むずかしい",
+        Kanji: "難しい",
+        Definition: "difficult / hard",
+      }
+      history.add(vocab);
+      const afterCache = history.Test.getEntries();
       expect(afterCache.length).toBe(beforeCache.length + 1);
     });
   });
 
   describe("check()", () => {
-    it("confirms the user's guess wasn't used in the current round", () => {
-      const history = History();
-      const addedEntry = {
-        slug: "1",
-        japanese: {
-          reading: "にほん",
-          word: "日本"
-        },
-        english: [],
-      };
-      const guess = {
+    let history;
+
+    beforeAll(() => {
+      history = History();
+      history.add({
         slug: "0",
         japanese: {
           reading: "ふくざつ",
           word: "複雑"
         },
-        english: [],
-      };
-      history.add(addedEntry);
-      expect(history.check(guess)).toBe(true);
+        english: ["complicated", "complex"],
+      });
+      history.add({
+        ID: "1",
+        Kana: "むずかしい",
+        Kanji: "難しい",
+        Definition: "difficult / hard",
+      });
     });
 
-    it("confirms the user's guess was already used in the current round", () => {
-      const history = History();
-      const addedEntry = {
-        slug: "1",
-        japanese: {
-          reading: "にほん",
-          word: "日本"
-        },
-        english: [],
-      };
-      history.add(addedEntry);
-      expect(history.check(addedEntry)).toBe(false);
+    it("returns FALSE bc word has already been used [id]", () => {
+      expect(history.check({ slug: "0" })).toBe(false);
+    });
+
+    it("returns FALSE bc word has already been used [id]", () => {
+      expect(
+        history.check({
+          ID: "1",
+          Kanji: "難しい",
+          Kana: "むずかしい"
+        })
+      ).toBe(false);
+    });
+
+    it("returns TRUE bc word hasn't been used [id]", () => {
+      expect(history.check({ slug: "1" })).toBe(true);
+    });
+
+    it("returns TRUE bc word hasn't been used [reading]", () => {
+      expect(
+        history.check({
+          slug: "2",
+          japanese: { reading: "ギリギリ", }
+        })).toBe(true);
+    });
+
+    it("returns TRUE bc word hasn't been used [kanji]", () => {
+      expect(
+        history.check({
+          slug: "2",
+          japanese: { word: "山", }
+        })).toBe(true);
+    });
+
+    it("returns FALSE bc word has been used [kanji]", () => {
+      expect(
+        history.check({
+          ID: "2",
+          Kanji: "難しい",
+          Kana: ""
+        })
+      ).toBe(false);
+    });
+
+    it("returns TRUE bc cached word has kanji - can't determine equality otherwise", () => {
+      expect(
+        history.check({
+          ID: "2",
+          Kanji: "",
+          Kana: "むずかしい"
+        })
+      ).toBe(true);
+    });
+
+    it("returns TRUE bc word hasn't been used [kanji]", () => {
+      expect(
+        history.check({
+          ID: "2",
+          Kanji: "学生",
+          Kana: ""
+        })
+      ).toBe(true);
+    });
+
+    it("returns TRUE bc word hasn't been used [reading]", () => {
+      expect(
+        history.check({
+          ID: "2",
+          Kanji: "",
+          Kana: "がくせい"
+        })
+      ).toBe(true);
+    });
+
+    it("returns TRUE bc word hasn't been used", () => {
+      expect(
+        history.check({
+          ID: "2",
+          Kanji: "学生",
+          Kana: "がくせい"
+        })
+      ).toBe(true);
     });
   });
 
@@ -71,12 +153,356 @@ describe("History()", () => {
       };
 
       history.add(confirmedEntry);
-      const beforeCache = history.test.getEntries();
+      const beforeCache = history.Test.getEntries();
       history.clear();
-      const afterCache = history.test.getEntries();
+      const afterCache = history.Test.getEntries();
 
       expect(beforeCache.length).toBe(1);
       expect(afterCache.length).toBe(0);
+    });
+  });
+
+  describe("helpers", () => {
+    let history;
+    let baseEntry;
+    let baseVocab;
+
+    beforeAll(() => {
+      history = History();
+      baseEntry = {
+        slug: "0",
+        japanese: {
+          reading: "ふくざつ",
+          word: "複雑"
+        },
+        english: ["complicated", "complex"],
+      };
+      baseVocab = {
+        ID: "0",
+        Kana: "ふくざつ",
+        Kanji: "複雑",
+        Definition: "complicated / complex",
+      };
+    });
+
+    afterEach(() => {
+      history.clear();
+    });
+
+    describe("isEntry()", () => {
+      it("TRUE just bc slug prop is included", () => {
+        const entry = { ...baseEntry };
+        expect(history.Test.isEntry(entry)).toBe(true);
+      });
+
+      it("TRUE despite other properties are missing", () => {
+        const entry = { ...baseEntry };
+        entry.japanese = {};
+        entry.english = [];
+        expect(history.Test.isEntry(entry)).toBe(true);
+      });
+
+      it("FALSE just bc slug is falsey", () => {
+        const entry = {
+          slug: "",
+          japanese: {},
+          english: [],
+        };
+        expect(history.Test.isEntry(entry)).toBe(false);
+      });
+
+      it("FALSE bc slug prop is falsey despite having all other properties", () => {
+        const entry = { ...baseEntry };
+        entry.slug = "";
+        expect(history.Test.isEntry(entry)).toBe(false);
+      });
+    });
+
+    describe("isVocabulary()", () => {
+      it("TRUE just bc ID prop is included", () => {
+        const vocab = {
+          ID: "0",
+          Kana: "",
+          Kanji: "",
+          Definition: "",
+        };
+        expect(history.Test.isVocabulary(vocab)).toBe(true);
+      });
+
+      it("FALSE just bc ID prop is falsey", () => {
+        const vocab = { ...baseVocab };
+        vocab.ID = "";
+        expect(history.Test.isVocabulary(vocab)).toBe(false);
+      });
+    });
+
+    describe("matchById()", () => {
+      it("matches Entry and Entry", () => {
+        const cachedEntry = { ...baseEntry };
+        history.add(cachedEntry);
+        const lookupEntry = {
+          slug: "0",
+          japanese: {},
+          english: []
+        };
+        expect(history.Test.matchById(lookupEntry, cachedEntry)).toBe(true);
+      });
+
+      it("matches Vocab and Vocab", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupVocab = {
+          ID: "0",
+          Kana: "",
+          Kanji: "",
+          Definition: "",
+        };
+        expect(history.Test.matchById(lookupVocab, cachedVocab)).toBe(true);
+      });
+
+      it("doesn't match Entry and Vocab", () => {
+        const cachedEntry = { ...baseEntry };
+        history.add(cachedEntry);
+        const lookupVocab = { ...baseVocab };
+        expect(history.Test.matchById(lookupVocab, cachedEntry)).toBe(false);
+      });
+
+      it("doesn't match Vocab and Entry", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupEntry = { ...baseEntry };
+        expect(history.Test.matchById(lookupEntry, cachedVocab)).toBe(false);
+      });
+    });
+
+    describe("matchByKanji()", () => {
+      it("matches Entry and Entry", () => {
+        const cachedEntry = { ...baseEntry };
+        history.add(cachedEntry);
+        const lookupEntry = {
+          ...baseEntry,
+          slug: "1",
+          japanese: {
+            word: "複雑"
+          },
+        };
+        expect(history.Test.matchByKanji(lookupEntry, cachedEntry)).toBe(true);
+      });
+
+      it("matches Vocab and Vocab", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupVocab = {
+          ...baseVocab,
+          ID: "1",
+          Kana: "",
+          Definition: "",
+        };
+        expect(history.Test.matchByKanji(lookupVocab, cachedVocab)).toBe(true);
+      });
+
+      it("matches Entry and Vocab", () => {
+        const cachedEntry = { ...baseEntry };
+        history.add(cachedEntry);
+        const lookupVocab = { ...baseVocab };
+        expect(history.Test.matchByKanji(lookupVocab, cachedEntry)).toBe(true);
+      });
+
+      it("matches Vocab and Entry", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupEntry = {
+          ...baseEntry,
+          japanese: {
+            word: "複雑"
+          },
+        };
+        expect(history.Test.matchByKanji(lookupEntry, cachedVocab)).toBe(true);
+      });
+
+      it("doesn't match bc both have different kanji", () => {
+        const cachedEntry = { ...baseEntry };
+        history.add(cachedEntry);
+        const lookupEntry = {
+          ...baseEntry,
+          slug: "1",
+          japanese: {
+            reading: "ふくざつ",
+            word: "簡単",
+          },
+        };
+        expect(history.Test.matchByKanji(lookupEntry, cachedEntry)).toBe(false);
+      });
+
+      it("doesn't match bc both have different kanji", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupVocab = {
+          ...baseVocab,
+          ID: "1",
+          Kana: "",
+          Kanji: "簡単",
+        };
+        expect(history.Test.matchByKanji(lookupVocab, cachedVocab)).toBe(false);
+      });
+
+      it("doesn't match bc both have different kanji", () => {
+        const cachedEntry = { ...baseEntry };
+        history.add(cachedEntry);
+        const lookupVocab = {
+          ...baseVocab,
+          Kanji: "簡単",
+        };
+        expect(history.Test.matchByKanji(lookupVocab, cachedEntry)).toBe(false);
+      });
+
+      it("doesn't match bc Entry doesn't have kanji", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupEntry = {
+          ...baseEntry,
+          japanese: {
+            reading: "ふくざつ",
+          },
+        };
+        expect(history.Test.matchByKanji(lookupEntry, cachedVocab)).toBe(false);
+      });
+    });
+
+    describe("matchByReading()", () => {
+      it("matches Entry and Entry", () => {
+        const cachedEntry = {
+          ...baseEntry,
+          japanese: {
+            reading: "ふくざつ",
+          },
+        };
+        history.add(cachedEntry);
+        const lookupEntry = {
+          ...baseEntry,
+          slug: "1",
+          japanese: {
+            reading: "ふくざつ",
+          },
+        };
+        expect(history.Test.matchByReading(lookupEntry, cachedEntry)).toBe(true);
+      });
+
+      it("matches Vocab and Vocab", () => {
+        const cachedVocab = {
+          ...baseVocab,
+          ID: "0",
+          Kanji: "",
+        };
+        history.add(cachedVocab);
+        const lookupVocab = {
+          ...baseVocab,
+          ID: "1",
+          Kanji: "",
+          Definition: "",
+        };
+        expect(history.Test.matchByReading(lookupVocab, cachedVocab)).toBe(true);
+      });
+
+      it("matches Entry and Vocab", () => {
+        const cachedEntry = {
+          ...baseEntry,
+          japanese: {
+            reading: "ふくざつ",
+          },
+        };
+        history.add(cachedEntry);
+        const lookupVocab = {
+          ...baseVocab,
+          Kanji: "",
+        };
+        expect(history.Test.matchByReading(lookupVocab, cachedEntry)).toBe(true);
+      });
+
+      it("matches Vocab and Entry", () => {
+        const cachedVocab = {
+          ...baseVocab,
+          Kanji: "",
+          Definition: "complex",
+        };
+        history.add(cachedVocab);
+        const lookupEntry = {
+          ...baseEntry,
+          japanese: {
+            reading: "ふくざつ",
+          },
+          english: [],
+        };
+        expect(history.Test.matchByReading(lookupEntry, cachedVocab)).toBe(true);
+      });
+
+      it("doesn't match Entry and Entry bc reading is different", () => {
+        const cachedEntry = {
+          ...baseEntry,
+          japanese: {
+            reading: "ふくざつ",
+          },
+        };
+        history.add(cachedEntry);
+        const lookupEntry = {
+          ...baseEntry,
+          slug: "1",
+          japanese: {
+            reading: "ふくざ",
+          },
+        };
+        expect(history.Test.matchByReading(lookupEntry, cachedEntry)).toBe(false);
+      });
+
+      it("doesn't match Vocab and Vocab bc reading is different", () => {
+        const cachedVocab = {
+          ...baseVocab,
+          Kanji: "",
+        };
+        history.add(cachedVocab);
+        const lookupVocab = {
+          ...baseVocab,
+          ID: "1",
+          Kana: "ざつ",
+          Kanji: "",
+        };
+        expect(history.Test.matchByReading(lookupVocab, cachedVocab)).toBe(false);
+      });
+
+      it("doesn't match bc Entry has kanji", () => {
+        const cachedEntry = { ...baseEntry };
+        history.add(cachedEntry);
+        const lookupVocab = {
+          ...baseVocab,
+          Kanji: "",
+        };
+        expect(history.Test.matchByReading(lookupVocab, cachedEntry)).toBe(false);
+      });
+
+      it("doesn't match bc Vocab has kanji", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupEntry = {
+          ...baseEntry,
+          japanese: {
+            reading: "ふくざつ",
+          },
+        };
+        expect(history.Test.matchByReading(lookupEntry, cachedVocab)).toBe(false);
+      });
+
+      it("doesn't match bc both have kanji", () => {
+        const cachedVocab = { ...baseVocab };
+        history.add(cachedVocab);
+        const lookupEntry = {
+          ...baseEntry,
+          japanese: {
+            reading: "ふくざつ",
+            word: "漢字"
+          },
+        };
+        expect(history.Test.matchByReading(lookupEntry, cachedVocab)).toBe(false);
+      });
     });
   });
 });


### PR DESCRIPTION
There was a regression with History and ensuring no duplicates were ever used as given words or allow the user to enter a used word as a guess. At least this time, it's much easier to read and split out into helpers.

1. Update `history.add()
  a. To take either `Entry | Vocabulary`
  b. Use to add the words used as `prevWord` or the given word for the user to base their answers off of
2. Update `history.check()` 
  a. To take either `Entry | Vocabulary`
  b. To compare either to either or both
3. Unit testing
4. Fix bug with consolidating the `English` definition array of strings with `/` being at the front