### PR TITLE
Filter Joshi results to include only words starting with the provided character

### DIFF
--- a/server/helpers.js
+++ b/server/helpers.js
@@ -1,6 +1,24 @@
 "use strict";
 exports.__esModule = true;
-exports.selectWord = exports.logger = exports.formatToEntry = exports.findAndSendMatch = void 0;
+exports.selectWord = exports.logger = exports.formatToEntry = exports.findAndSendMatch = exports.filterByChar = void 0;
+var katakanaToHiragana = {
+    "ア": "あ", "イ": "い", "ウ": "う", "エ": "え", "オ": "お",
+    "カ": "か", "キ": "き", "ク": "く", "ケ": "け", "コ": "こ",
+    "ガ": "が", "ギ": "ぎ", "グ": "ぐ", "ゲ": "げ", "ゴ": "ご",
+    "サ": "さ", "シ": "し", "ス": "す", "セ": "せ", "ソ": "そ",
+    "ザ": "ざ", "ジ": "じ", "ズ": "ず", "ゼ": "ぜ", "ゾ": "ぞ",
+    "タ": "た", "チ": "ち", "ツ": "つ", "テ": "て", "ト": "と",
+    "ダ": "だ", "ヂ": "ぢ", "デ": "で", "ド": "ど",
+    "ナ": "な", "ニ": "に", "ヌ": "ぬ", "ネ": "ね", "ノ": "の",
+    "ハ": "は", "ヒ": "ひ", "フ": "ふ", "ヘ": "へ", "ホ": "ほ",
+    "バ": "ば", "ビ": "び", "ブ": "ぶ", "ベ": "べ", "ボ": "ぼ",
+    "パ": "ぱ", "ピ": "ぴ", "プ": "ぷ", "ペ": "ぺ", "ポ": "ぽ",
+    "マ": "ま", "ミ": "み", "ム": "む", "メ": "め", "モ": "も",
+    "ラ": "ら", "リ": "り", "ル": "る", "レ": "れ", "ロ": "ろ",
+    "ヤ": "や", "ユ": "ゆ", "ヨ": "よ", "ワ": "わ", "ヲ": "を",
+    "ッ": "っ", "ャ": "ゃ", "ュ": "ゅ", "ョ": "ょ", "ン": "ん",
+    "ァ": "ぁ", "ィ": "ぃ", "ゥ": "ぅ", "ェ": "ぇ", "ォ": "ぉ"
+};
 function findAndSendMatch(query, receivedResp, res) {
     for (var i in receivedResp.data) {
         var searchResult = findWord(query, receivedResp.data[i]);
@@ -78,6 +96,21 @@ function formatToEntry(element) {
     return entry;
 }
 exports.formatToEntry = formatToEntry;
+function filterByChar(char, results) {
+    return results.filter(function (el) {
+        var _a, _b;
+        var elFirstChar = (_b = (_a = el.japanese[0]) === null || _a === void 0 ? void 0 : _a.reading) === null || _b === void 0 ? void 0 : _b.substr(0, 1);
+        if (!elFirstChar)
+            return false;
+        var firstCharKana = katakanaToHiragana[elFirstChar];
+        var charKana = katakanaToHiragana[char];
+        if (!firstCharKana) {
+            return elFirstChar.localeCompare(charKana || char) === 0;
+        }
+        return firstCharKana.localeCompare(charKana || char) === 0;
+    });
+}
+exports.filterByChar = filterByChar;
 function logger(req, _, next) {
     if (req.method !== "POST" && req.url !== "/search") {
         console.log(req.method, req.url, req.body);

--- a/server/helpers.ts
+++ b/server/helpers.ts
@@ -14,7 +14,7 @@ interface JapaneseEntry {
 }
 interface Sense {
   english_definitions: Array<string>;
-  sentences: Array<string>;
+  sentences?: Array<string>;
 }
 
 interface ApiResponse {
@@ -25,6 +25,25 @@ interface ApiEntry {
   slug: string;
   japanese: JapaneseEntry;
   english: Array<string>;
+}
+
+const katakanaToHiragana = {
+  "ア": "あ", "イ": "い", "ウ": "う", "エ": "え", "オ": "お",
+  "カ": "か", "キ": "き", "ク": "く", "ケ": "け", "コ": "こ",
+  "ガ": "が", "ギ": "ぎ", "グ": "ぐ", "ゲ": "げ", "ゴ": "ご",
+  "サ": "さ", "シ": "し", "ス": "す", "セ": "せ", "ソ": "そ",
+  "ザ": "ざ", "ジ": "じ", "ズ": "ず", "ゼ": "ぜ", "ゾ": "ぞ",
+  "タ": "た", "チ": "ち", "ツ": "つ", "テ": "て", "ト": "と",
+  "ダ": "だ", "ヂ": "ぢ", "デ": "で", "ド": "ど",
+  "ナ": "な", "ニ": "に", "ヌ": "ぬ", "ネ": "ね", "ノ": "の",
+  "ハ": "は", "ヒ": "ひ", "フ": "ふ", "ヘ": "へ", "ホ": "ほ",
+  "バ": "ば", "ビ": "び", "ブ": "ぶ", "ベ": "べ", "ボ": "ぼ",
+  "パ": "ぱ", "ピ": "ぴ", "プ": "ぷ", "ペ": "ぺ", "ポ": "ぽ",
+  "マ": "ま", "ミ": "み", "ム": "む", "メ": "め", "モ": "も",
+  "ラ": "ら", "リ": "り", "ル": "る", "レ": "れ", "ロ": "ろ",
+  "ヤ": "や", "ユ": "ゆ", "ヨ": "よ", "ワ": "わ", "ヲ": "を",
+  "ッ": "っ", "ャ": "ゃ", "ュ": "ゅ", "ョ": "ょ", "ン": "ん",
+  "ァ": "ぁ", "ィ": "ぃ", "ゥ": "ぅ", "ェ": "ぇ", "ォ": "ぉ",
 }
 
 function findAndSendMatch(query: string, receivedResp: JoshiResponse, res: Response): boolean {
@@ -118,6 +137,21 @@ function formatToEntry(element: JoshiElement): ApiEntry {
   return entry;
 }
 
+function filterByChar(char: string, results: Array<JoshiElement>): Array<JoshiElement> {
+  return results.filter(el => {
+    const elFirstChar = el.japanese[0]?.reading?.substr(0, 1);
+    if (!elFirstChar) return false;
+
+    const firstCharKana = katakanaToHiragana[elFirstChar];
+    const charKana = katakanaToHiragana[char];
+
+    if (!firstCharKana) {
+      return elFirstChar.localeCompare(charKana || char) === 0;
+    }
+    return firstCharKana.localeCompare(charKana || char) === 0;
+  });
+}
+
 function logger(req: Request, _, next: Next) {
   if (req.method !== "POST" && req.url !== "/search") {
     console.log(req.method, req.url, req.body);
@@ -130,6 +164,7 @@ function logger(req: Request, _, next: Next) {
 }
 
 export {
+  filterByChar,
   findAndSendMatch,
   formatToEntry,
   logger,

--- a/server/index.js
+++ b/server/index.js
@@ -48,7 +48,7 @@ app.get("/api/words-starting-with/:character", function (req, res) {
             res.send({ found: false, msg: "No data" });
             return;
         }
-        var word = helpers_1.selectWord(r.data);
+        var word = helpers_1.selectWord(helpers_1.filterByChar(decodedChar, r.data));
         if (!word) {
             console.log("no word");
             res.send({ found: false, response: r });

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ const express = require('express');
 const fs = require("fs");
 
 import {
+  filterByChar,
   findAndSendMatch,
   formatToEntry,
   logger,
@@ -60,8 +61,10 @@ app.get("/api/words-starting-with/:character", (req: Request, res: Response) => 
         res.send({ found: false, msg: "No data" });
         return;
       }
-      // TODO: filter 'results' to ensure they actually start with the right character
-      const word = selectWord(r.data)
+
+      const word = selectWord(
+        filterByChar(decodedChar, r.data)
+      );
       if (!word) {
         console.log(`no word`);
         res.send({ found: false, response: r });

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,117 @@
+import { filterByChar } from "../server/helpers";
+
+describe("helpers", () => {
+  describe("filterByChar()", () => {
+    const results = [
+      {
+        "slug": "留守",
+        "japanese": [
+          {
+            "word": "留守",
+            "reading": "るす"
+          },
+          {
+            "word": "留主",
+            "reading": "るす"
+          }
+        ],
+        "senses": [
+          {
+            "english_definitions": [
+              "absence",
+              "being away from home"
+            ]
+          }
+        ]
+      },
+      {
+        "slug": "留守番",
+        "japanese": [
+          {
+            "word": "留守番",
+            "reading": "るすばん"
+          }
+        ],
+        "senses": [
+          {
+            "english_definitions": [
+              "care-taking",
+              "house-sitting",
+              "house-watching",
+              "staying at home"
+            ]
+          },
+        ]
+      },
+      {
+        "slug": "リズム",
+        "japanese": [
+          {
+            "reading": "リズム"
+          },
+          {
+            "reading": "ルズム"
+          }
+        ],
+        "senses": [
+          {
+            "english_definitions": [
+              "rhythm"
+            ]
+          },
+        ]
+      }
+    ];
+
+    it("filters by the character given", () => {
+      const char = "る";
+      const result = filterByChar(char, results);
+      expect(
+        result.map(
+          el => el.japanese[0].reading.substr(0, 1)
+        )
+      )
+        .not.toContain("リ");
+    });
+
+    it("returns the expected array of JoshiElement", () => {
+      const char = "る";
+      const result = filterByChar(char, results)
+      expect(
+        result.map(el => el.slug)
+      ).toEqual(
+        ["留守", "留守番"]
+      );
+    });
+
+    it("converts Katakana to Hiragana", () => {
+      const char = "ル";
+      const result = filterByChar(char, results);
+      expect(
+        result.map(el => el.japanese[0].reading.substr(0, 1))
+      ).toEqual(
+        ["る", "る"]
+      );
+    });
+
+    it("doesn't fail when the element's japanese object doesn't have a 'reading' prop", () => {
+      const char = "る";
+      const extendedResults = [
+        ...results,
+        {
+          slug: "ルール",
+          japanese: [{ word: "ルール" }],
+          senses: [
+            { english_definitions: ["rule"] }
+          ]
+        }
+      ];
+      const result = filterByChar(char, extendedResults);
+      expect(
+        result.map(el => el.japanese[0].reading.substr(0, 1))
+      ).toEqual(
+        ["る", "る"]
+      );
+    });
+  });
+});

--- a/vocab-n4.json
+++ b/vocab-n4.json
@@ -858,8 +858,8 @@
     },
     {
       "ID": "N4#142",
-      "Kana": "かねもち/おかねもち",
-      "Kanji": "お・金持ち",
+      "Kana": "かねもち",
+      "Kanji": "金持ち",
       "Definition": "rich man"
     },
     {
@@ -1290,7 +1290,7 @@
     },
     {
       "ID": "N4#212",
-      "Kana": "けれど/けれども",
+      "Kana": "けれど",
       "Kanji": "",
       "Definition": "but, however"
     },


### PR DESCRIPTION
Joshi's API also returns words associated or also known by a different spelling with the provided character
Ex: Despite searching for `る*`, `リズム` would come back as a result because it can be spelled like `ルズム`

1. Filter out said results
2. Account for possible Katakana results as well
3. Unit testing
4. Maintain consistency with N4 JSON -- only one `Kana` to alleviate confusion and simplicity 